### PR TITLE
fix(tools): Replace git branch get name method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-commits",
   "private": false,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A CLI for creating better commits following the conventional commit guidelines",
   "author": "Erik Verduin (https://github.com/everduin94)",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-commits",
   "private": false,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A CLI for creating better commits following the conventional commit guidelines",
   "author": "Erik Verduin (https://github.com/everduin94)",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,10 @@ To simplify the CLI, some rules are enforced at runtime to make sure the program
 - if you're using Github issues to track your work, and select the `closes` footer option when writing your commit. Github will **automatically link and close** that issue when your **pr is merged**
 - [better-commits](https://packagephobia.com/result?p=better-commits) is much smaller than its alternative [commitizen](https://packagephobia.com/result?p=commitizen)
 
+## ❓ Troubleshooting
+
+`TTY initialization failed: uv_tty_init returned EBADF (bad file descriptor)`. This may happen because you're running something like git-bash on Windows. Try another terminal/command-prompt or `winpty` to see if its still an issue.
+
 ## Alternatives
 - Commitizen
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ async function main(config: z.infer<typeof Config>) {
 
   if (config.check_ticket.infer_ticket) {
     try {
-      const branch = execSync('git rev-parse --abbrev-ref HEAD', {stdio : 'pipe' }).toString();
+      const branch = execSync('git branch --show-current', {stdio : 'pipe' }).toString();
       const found: string[] = [branch.match(REGEX_SLASH_TAG), branch.match(REGEX_SLASH_NUM) , branch.match(REGEX_START_TAG), branch.match(REGEX_START_NUM)]
       .filter(v => v != null)
       .map(v => v && v.length >= 2 ?  v[1] : '')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,7 @@ export const FOOTER_OPTION_VALUES: FOOTER_OPTIONS[] = ['closes', 'breaking-chang
 export function infer_type_from_branch(types: string[]): string {
   let branch = ''
   try {
-    branch = execSync('git rev-parse --abbrev-ref HEAD', {stdio : 'pipe' }).toString();
+    branch = execSync('git branch --show-current', {stdio : 'pipe' }).toString();
   } catch (err) {
     return ''
   }


### PR DESCRIPTION
Given a new repository with 0 commits "git rev-parse --abbrev-ref HEAD" would return an error. Replaced it with "git branch --show-current"