### PR TITLE
feat(tools): added custom footer option

### DIFF
--- a/.better-commits.json
+++ b/.better-commits.json
@@ -1,59 +1,19 @@
 {
-	"check_status": true,
-	"commit_type": {
-		"enable": true,
-		"initial_value": "feat",
-		"infer_type_from_branch": true,
-		"options": [
-			{
-				"value": "feat",
-				"label": "feat"
-			},
-			{
-				"value": "fix",
-				"label": "fix"
-			},
-			{
-				"value": "docs",
-				"label": "docs"
-			},
-			{
-				"value": "refactor",
-				"label": "refactor"
-			},
-			{
-				"value": "perf",
-				"label": "perf"
-			},
-			{
-				"value": "test",
-				"label": "test"
-			},
-			{
-				"value": "",
-				"label": "none"
-			}
-		]
-	},
 	"commit_scope": {
 		"enable": true,
-		"initial_value": "app",
+		"initial_value": "main",
 		"options": [
 			{
-				"value": "app",
-				"label": "app"
+				"value": "main",
+				"label": "main"
 			},
 			{
-				"value": "shared",
-				"label": "shared"
+				"value": "init",
+				"label": "init"
 			},
-			{
-				"value": "server",
-				"label": "server"
-			},
-			{
-				"value": "tools",
-				"label": "tools"
+      {
+				"value": "util",
+				"label": "util"
 			},
 			{
 				"value": "",
@@ -62,30 +22,6 @@
 		]
 	},
 	"check_ticket": {
-		"infer_ticket": true,
-		"confirm_ticket": true,
-		"add_to_title": true,
-		"append_hashtag": false
-	},
-	"commit_title": {
-		"max_size": 70
-	},
-	"commit_body": {
-		"enable": true,
-		"required": false
-	},
-	"commit_footer": {
-		"enable": true,
-		"initial_value": [],
-		"options": [
-			"closes",
-			"breaking-change",
-			"deprecated",
-			"custom"
-		]
-	},
-	"breaking_change": {
-		"add_exclamation_to_title": true
-	},
-	"confirm_commit": true
+		"append_hashtag": true
+	}
 }

--- a/.better-commits.json
+++ b/.better-commits.json
@@ -1,0 +1,91 @@
+{
+	"check_status": true,
+	"commit_type": {
+		"enable": true,
+		"initial_value": "feat",
+		"infer_type_from_branch": true,
+		"options": [
+			{
+				"value": "feat",
+				"label": "feat"
+			},
+			{
+				"value": "fix",
+				"label": "fix"
+			},
+			{
+				"value": "docs",
+				"label": "docs"
+			},
+			{
+				"value": "refactor",
+				"label": "refactor"
+			},
+			{
+				"value": "perf",
+				"label": "perf"
+			},
+			{
+				"value": "test",
+				"label": "test"
+			},
+			{
+				"value": "",
+				"label": "none"
+			}
+		]
+	},
+	"commit_scope": {
+		"enable": true,
+		"initial_value": "app",
+		"options": [
+			{
+				"value": "app",
+				"label": "app"
+			},
+			{
+				"value": "shared",
+				"label": "shared"
+			},
+			{
+				"value": "server",
+				"label": "server"
+			},
+			{
+				"value": "tools",
+				"label": "tools"
+			},
+			{
+				"value": "",
+				"label": "none"
+			}
+		]
+	},
+	"check_ticket": {
+		"infer_ticket": true,
+		"confirm_ticket": true,
+		"add_to_title": true,
+		"append_hashtag": false
+	},
+	"commit_title": {
+		"max_size": 70
+	},
+	"commit_body": {
+		"enable": true,
+		"required": false
+	},
+	"commit_footer": {
+		"enable": true,
+		"initial_value": [],
+		"options": [
+			"closes",
+			"breaking-change",
+			"deprecated",
+			"custom"
+		]
+	},
+	"breaking_change": {
+		"add_exclamation_to_title": true
+	},
+	"confirm_commit": true
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-commits",
   "private": false,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A CLI for creating better commits following the conventional commit guidelines",
   "author": "Erik Verduin (https://github.com/everduin94)",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,7 @@ import { execSync } from 'child_process';
 import { z } from "zod";
 import { fromZodError } from 'zod-validation-error';
 import { CommitState, Config } from './zod-state';
-import { CONFIG_FILE_NAME, get_default_config_path, check_missing_stage, addNewLine, SPACE_TO_SELECT, REGEX_SLASH_TAG, REGEX_SLASH_NUM, REGEX_START_TAG, REGEX_START_NUM, OPTIONAL_PROMPT, clean_commit_title, COMMIT_FOOTER_OPTIONS, infer_type_from_branch } from './utils';
-import { Z_FOOTER_OPTIONS } from '../dist/utils';
+import { CONFIG_FILE_NAME, get_default_config_path, check_missing_stage, addNewLine, SPACE_TO_SELECT, REGEX_SLASH_TAG, REGEX_SLASH_NUM, REGEX_START_TAG, REGEX_START_NUM, OPTIONAL_PROMPT, clean_commit_title, COMMIT_FOOTER_OPTIONS, infer_type_from_branch, Z_FOOTER_OPTIONS } from './utils';
 
 main(load_setup());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ import { execSync } from 'child_process';
 import { z } from "zod";
 import { fromZodError } from 'zod-validation-error';
 import { CommitState, Config } from './zod-state';
-import { CONFIG_FILE_NAME, get_default_config_path, check_missing_stage, addNewLine, SPACE_TO_SELECT, REGEX_SLASH_TAG, REGEX_SLASH_NUM, REGEX_START_TAG, REGEX_START_NUM, OPTIONAL_PROMPT, clean_commit_title, COMMIT_FOOTER_OPTIONS, infer_type_from_branch, FooterOptions } from './utils';
+import { CONFIG_FILE_NAME, get_default_config_path, check_missing_stage, addNewLine, SPACE_TO_SELECT, REGEX_SLASH_TAG, REGEX_SLASH_NUM, REGEX_START_TAG, REGEX_START_NUM, OPTIONAL_PROMPT, clean_commit_title, COMMIT_FOOTER_OPTIONS, infer_type_from_branch } from './utils';
+import { Z_FOOTER_OPTIONS } from '../dist/utils';
 
 main(load_setup());
 
@@ -176,9 +177,9 @@ async function main(config: z.infer<typeof Config>) {
     const commit_footer = await p.multiselect({
             message: `Select optional footers ${SPACE_TO_SELECT}`,
             initialValues: config.commit_footer.initial_value,
-            options: COMMIT_FOOTER_OPTIONS as {value: FooterOptions, label: string, hint: string}[],
+            options: COMMIT_FOOTER_OPTIONS as {value: z.infer<typeof Z_FOOTER_OPTIONS>, label: string, hint: string}[],
             required: false
-    }) as (FooterOptions)[]
+    }) 
     if (p.isCancel(commit_footer)) process.exit(0)
 
     if (commit_footer.includes('breaking-change')) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,6 @@ export const DEFAULT_SCOPE_OPTIONS = [
     { value: 'tools', label: 'tools' },
     { value: '', label: 'none'},
 ]
-export type FooterOptions = 'closes' | 'breaking-change' | 'deprecated' | 'custom'
 export const COMMIT_FOOTER_OPTIONS = [
   { value: 'closes', label: 'closes <issue/ticket>', hint: 'Attempts to infer ticket from branch'},
   { value: 'breaking-change', label: 'breaking change', hint: 'Add breaking change'},
@@ -35,9 +34,8 @@ export const COMMIT_FOOTER_OPTIONS = [
   { value: 'custom', label: 'custom', hint: 'Add a custom footer'},
 ]
 
-// TODO: This could be better
 export const Z_FOOTER_OPTIONS = z.enum(['closes', 'breaking-change', 'deprecated', 'custom'])
-export const FOOTER_OPTION_VALUES: FooterOptions[] = ['closes', 'breaking-change', 'deprecated', 'custom']
+export const FOOTER_OPTION_VALUES: z.infer<typeof Z_FOOTER_OPTIONS>[] = ['closes', 'breaking-change', 'deprecated', 'custom']
 
 export function infer_type_from_branch(types: string[]): string {
   let branch = ''

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,16 +27,17 @@ export const DEFAULT_SCOPE_OPTIONS = [
     { value: 'tools', label: 'tools' },
     { value: '', label: 'none'},
 ]
-export type FOOTER_OPTIONS = 'closes' | 'breaking-change' | 'deprecated'
+export type FooterOptions = 'closes' | 'breaking-change' | 'deprecated' | 'custom'
 export const COMMIT_FOOTER_OPTIONS = [
   { value: 'closes', label: 'closes <issue/ticket>', hint: 'Attempts to infer ticket from branch'},
   { value: 'breaking-change', label: 'breaking change', hint: 'Add breaking change'},
   { value: 'deprecated', label: 'deprecated', hint: 'Add deprecated change'},
+  { value: 'custom', label: 'custom', hint: 'Add a custom footer'},
 ]
 
 // TODO: This could be better
-export const Z_FOOTER_OPTIONS = z.enum(['closes', 'breaking-change', 'deprecated'])
-export const FOOTER_OPTION_VALUES: FOOTER_OPTIONS[] = ['closes', 'breaking-change', 'deprecated']
+export const Z_FOOTER_OPTIONS = z.enum(['closes', 'breaking-change', 'deprecated', 'custom'])
+export const FOOTER_OPTION_VALUES: FooterOptions[] = ['closes', 'breaking-change', 'deprecated', 'custom']
 
 export function infer_type_from_branch(types: string[]): string {
   let branch = ''

--- a/src/zod-state.ts
+++ b/src/zod-state.ts
@@ -1,7 +1,6 @@
 import { z } from "zod"
 import { DEFAULT_SCOPE_OPTIONS, DEFAULT_TYPE_OPTIONS, FOOTER_OPTION_VALUES, Z_FOOTER_OPTIONS } from "./utils"
 
-
 // TODO: add "Ref", "Fixes", ability to change phrase "Closes/closes/closes:"
 export const Config = z.object({
    check_status: z.boolean().default(true),
@@ -67,4 +66,5 @@ export const CommitState = z.object({
   deprecates: z.string().default(''),
   deprecates_title: z.string().default(''),
   deprecates_body: z.string().default(''),
+  custom_footer: z.string().default(''),
 }).default({})


### PR DESCRIPTION
 added optional customer footer to footer options. This is a stop-gap for things like:
 reference: ticket, fixes: ticket (or any combination of these)
    
 This is a better-commits commit, using the feature being committed 🤯
