### PR TITLE
feat(main): #10 add hints to default types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-commits",
   "private": false,
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A CLI for creating better commits following the conventional commit guidelines",
   "author": "Erik Verduin (https://github.com/everduin94)",
   "keywords": [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,12 +12,14 @@ export const REGEX_START_TAG = new RegExp(/^(\w+-\d+)/)
 export const REGEX_SLASH_NUM = new RegExp(/\/(\d+)/)
 export const REGEX_START_NUM = new RegExp(/^(\d+)/)
 export const DEFAULT_TYPE_OPTIONS = [
-    { value: 'feat', label: 'feat' },
-    { value: 'fix', label: 'fix' },
-    { value: 'docs', label: 'docs'},
-    { value: 'refactor', label: 'refactor'},
-    { value: 'perf', label: 'perf'},
-    { value: 'test', label: 'test'},
+    { value: 'feat', label: 'feat' , hint: 'A new feature'},
+    { value: 'fix', label: 'fix' , hint: 'A bug fix'},
+    { value: 'docs', label: 'docs', hint: 'Documentation only changes'},
+    { value: 'refactor', label: 'refactor', hint: 'A code change that neither fixes a bug nor adds a feature'},
+    { value: 'perf', label: 'perf', hint: 'A code change that improves performance'},
+    { value: 'test', label: 'test', hint: 'Adding missing tests or correcting existing tests'},
+    { value: 'build', label: 'build', hint: 'Changes that affect the build system or external dependencies'},
+    { value: 'ci', label: 'ci', hint: 'Changes to our CI configuration files and scripts'},
     { value: '', label: 'none'},
 ]
 export const DEFAULT_SCOPE_OPTIONS = [


### PR DESCRIPTION
hints based on the conventional commit examples have been added to types. additionally, added build and ci to defaults

Closes: #10