### PR TITLE
feat(main): #14 print commit output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-commits",
   "private": false,
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A CLI for creating better commits following the conventional commit guidelines",
   "author": "Erik Verduin (https://github.com/everduin94)",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -165,7 +165,8 @@ All properties are optional, they can be removed from your configuration and wil
 	"breaking_change": {
 		"add_exclamation_to_title": true
 	},
-	"confirm_commit": true
+	"confirm_commit": true,
+	"print_commit_output": true
 }
 ```
 

--- a/src/zod-state.ts
+++ b/src/zod-state.ts
@@ -51,7 +51,8 @@ export const Config = z.object({
    breaking_change: z.object({
       add_exclamation_to_title: z.boolean().default(true)
    }).default({}),
-   confirm_commit: z.boolean().default(true)
+   confirm_commit: z.boolean().default(true),
+   print_commit_output: z.boolean().default(true)
 }).default({})
 
 export const CommitState = z.object({


### PR DESCRIPTION
added a config *print_commit_output* (default true) that will print the native git output, this should resolve any issues with pre-commit hooks not printing their output

EDIT: The library *simple git* was nullifying the output of the commit & any pre-commit hooks. Originally I thought the pre-commit hooks would print because I started explicitly logging the result. -- Actually, pre-commit hooks are printing now because we aren't using simple git. Hence, if you disable *print_commit_output*, pre-commit hooks will still print (but the actual git message will not). I think this is an okay tradeoff, because most people probably expect their pre-commit hooks to print. Also, the info log with the commit output looks better because you get the type of output you would normally expect from a `git commit` command at the end

Closes: #14