### PR TITLE
feat(main): add body max line length checking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,10 +166,27 @@ async function main(config: z.infer<typeof Config>) {
 
   if (config.commit_body.enable) {
     const commit_body = await p.text({
-            message: `Write a detailed description of the changes ${OPTIONAL_PROMPT}`,
+            message: `Write a detailed description of the changes ${OPTIONAL_PROMPT}. Use \\n to create a new line`,
             placeholder: '',
             validate: (val) => {
               if (config.commit_body.required && !val) return 'Please enter a description' 
+              if (config.commit_body.max_line_length !== undefined) {
+                const lineMaxLength = config.commit_body.max_line_length;
+                const lines = val.split("\\n");
+                var exceedLineNumber: number | undefined;
+                var lineLength: number | undefined;
+                if (lines.some((line, index) => {
+                  if (line.length > lineMaxLength) {
+                    exceedLineNumber = index+1;
+                    lineLength = line.length;
+
+                    return true;
+                  }
+                  
+                })) {
+                  return `Line ${exceedLineNumber} exceeds max length. Max line length [${lineMaxLength}], current length [${lineLength}]`
+                }
+              }
             }
         
     })

--- a/src/zod-state.ts
+++ b/src/zod-state.ts
@@ -53,6 +53,7 @@ export const Config = z.object({
    commit_body: z.object({
      enable: z.boolean().default(true),
      required: z.boolean().default(false),
+     max_line_length: z.number().optional(),
    }).default({}),
    commit_footer:  z.object({
      enable: z.boolean().default(true),


### PR DESCRIPTION
Add checking that the line length of any given body line is not longer than a specified value This satisfies commit body length restrictions.
Also includes explicit description of how to create new lines in commit body