### PR TITLE
✨ feat(main): #31 added support for emojis

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,53 +64,64 @@ All properties are optional, they can be removed from your configuration and wil
     "check_status": true,
     "commit_type": {
         "enable": true,
-        "initial_value": "feat",
+        "initial_value": "✨ feat",
         "infer_type_from_branch": true,
+        "append_emoji_to_label": false,
+        "append_emoji_to_commit": false,
         "options": [
             {
                 "value": "feat",
                 "label": "feat",
-                "hint": "A new feature"
+                "hint": "A new feature",
+                "emoji": "🌈"
             },
             {
                 "value": "fix",
                 "label": "fix",
-                "hint": "A bug fix"
+                "hint": "A bug fix",
+                "emoji": "🐛"
             },
             {
                 "value": "docs",
                 "label": "docs",
-                "hint": "Documentation only changes"
+                "hint": "Documentation only changes",
+                "emoji": "📚"
             },
             {
                 "value": "refactor",
                 "label": "refactor",
-                "hint": "A code change that neither fixes a bug nor adds a feature"
+                "hint": "A code change that neither fixes a bug nor adds a feature",
+                "emoji": "🔨"
             },
             {
                 "value": "perf",
                 "label": "perf",
-                "hint": "A code change that improves performance"
+                "hint": "A code change that improves performance",
+                "emoji": "🚀"
             },
             {
                 "value": "test",
                 "label": "test",
-                "hint": "Adding missing tests or correcting existing tests"
+                "hint": "Adding missing tests or correcting existing tests",
+                "emoji": "🚨"
             },
             {
                 "value": "build",
                 "label": "build",
-                "hint": "Changes that affect the build system or external dependencies"
+                "hint": "Changes that affect the build system or external dependencies",
+                "emoji": "🚧"
             },
             {
                 "value": "ci",
                 "label": "ci",
-                "hint": "Changes to our CI configuration files and scripts"
+                "hint": "Changes to our CI configuration files and scripts",
+                "emoji": "🤖"
             },
             {
                 "value": "chore",
                 "label": "chore",
-                "hint": "Other changes that do not modify src or test files"
+                "hint": "Other changes that do not modify src or test files",
+                "emoji": "🧹"
             },
             {
                 "value": "",

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ All properties are optional, they can be removed from your configuration and wil
     "check_status": true,
     "commit_type": {
         "enable": true,
-        "initial_value": "✨ feat",
+        "initial_value": "feat",
         "infer_type_from_branch": true,
         "append_emoji_to_label": false,
         "append_emoji_to_commit": false,
@@ -73,7 +73,7 @@ All properties are optional, they can be removed from your configuration and wil
                 "value": "feat",
                 "label": "feat",
                 "hint": "A new feature",
-                "emoji": "🌈"
+                "emoji": "✨"
             },
             {
                 "value": "fix",

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,9 @@ async function main(config: z.infer<typeof Config>) {
       const type_from_branch = infer_type_from_branch(options)
       if (type_from_branch) initial_value = type_from_branch
     }
+    const value_to_emoji: Record<string,string> = config.commit_type.options.reduce(
+      (acc, curr) => ({ ...acc, [curr.value]: curr.emoji ?? '' }), {}
+    )
     const commit_type = await p.select(
         {
           message: `Select a commit type`,
@@ -103,7 +106,9 @@ async function main(config: z.infer<typeof Config>) {
         }
     )
     if (p.isCancel(commit_type)) process.exit(0)
-    commit_state.type = commit_type;
+    commit_state.type = config.commit_type.append_emoji_to_commit ?
+      `${value_to_emoji[commit_type]} ${commit_type}`.trim()
+    : commit_type;
   }
 
   if (config.commit_scope.enable) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,15 +12,15 @@ export const REGEX_START_TAG = new RegExp(/^(\w+-\d+)/)
 export const REGEX_SLASH_NUM = new RegExp(/\/(\d+)/)
 export const REGEX_START_NUM = new RegExp(/^(\d+)/)
 export const DEFAULT_TYPE_OPTIONS = [
-    { value: 'feat', label: 'feat' , hint: 'A new feature'},
-    { value: 'fix', label: 'fix' , hint: 'A bug fix'},
-    { value: 'docs', label: 'docs', hint: 'Documentation only changes'},
-    { value: 'refactor', label: 'refactor', hint: 'A code change that neither fixes a bug nor adds a feature'},
-    { value: 'perf', label: 'perf', hint: 'A code change that improves performance'},
-    { value: 'test', label: 'test', hint: 'Adding missing tests or correcting existing tests'},
-    { value: 'build', label: 'build', hint: 'Changes that affect the build system or external dependencies'},
-    { value: 'ci', label: 'ci', hint: 'Changes to our CI configuration files and scripts'},
-    { value: 'chore', label: 'chore', hint: 'Other changes that do not modify src or test files'},
+    { value: 'feat', label: 'feat' , hint: 'A new feature', emoji: '✨'},
+    { value: 'fix', label: 'fix' , hint: 'A bug fix', emoji: '🐛'},
+    { value: 'docs', label: 'docs', hint: 'Documentation only changes', emoji: '📚'},
+    { value: 'refactor', label: 'refactor', hint: 'A code change that neither fixes a bug nor adds a feature', emoji: '🔨'},
+    { value: 'perf', label: 'perf', hint: 'A code change that improves performance', emoji: '🚀'},
+    { value: 'test', label: 'test', hint: 'Adding missing tests or correcting existing tests', emoji: '🚨'},
+    { value: 'build', label: 'build', hint: 'Changes that affect the build system or external dependencies', emoji: '🚧'},
+    { value: 'ci', label: 'ci', hint: 'Changes to our CI configuration files and scripts', emoji: '🤖'},
+    { value: 'chore', label: 'chore', hint: 'Other changes that do not modify src or test files', emoji: '🧹'},
     { value: '', label: 'none'},
 ]
 export const DEFAULT_SCOPE_OPTIONS = [

--- a/src/zod-state.ts
+++ b/src/zod-state.ts
@@ -6,17 +6,28 @@ export const Config = z.object({
    check_status: z.boolean().default(true),
    commit_type: z.object({
      enable: z.boolean().default(true),
-     initial_value: z.string().default('feat'),
+     initial_value: z.string().default('✨ feat'),
      infer_type_from_branch: z.boolean().default(true),
+     append_emoji_to_label: z.boolean().default(false),
+     append_emoji_to_commit: z.boolean().default(false),
      options: z.array(z.object({
       value: z.string(),
       label: z.string().optional(),
       hint: z.string().optional(),
+      emoji: z.string().emoji().optional(),
      })).default(DEFAULT_TYPE_OPTIONS)
-   }).default({}).refine(val => {
-     const options = val.options.map(v => v.value)
-    return options.includes(val.initial_value)
-  }, (val) => ({ message: `Type: initial_value "${val.initial_value}" must exist in options` })),
+   }).default({}).transform(val => {
+      const options = val.options.map(v => ({
+        ...v,
+        label: v.emoji && val.append_emoji_to_label ? `${v.emoji} ${v.label}` : v.label,
+        value: v.emoji && val.append_emoji_to_commit ? `${v.emoji} ${v.value}` : v.value,
+      }))
+      return { ...val, options }
+    })
+   .refine(val => {
+     const options = val.options.map(v => ({value: v.value, emoji: v.emoji}) )
+     return options.some(o => val.append_emoji_to_commit ? `${o.emoji} ${o.value}` : `${o.value}`)
+   }, (val) => ({ message: `Type: initial_value "${val.initial_value}" must exist in options` })),
    commit_scope: z.object({
      enable: z.boolean().default(true),
      custom_scope: z.boolean().default(false),

--- a/src/zod-state.ts
+++ b/src/zod-state.ts
@@ -20,14 +20,11 @@ export const Config = z.object({
       const options = val.options.map(v => ({
         ...v,
         label: v.emoji && val.append_emoji_to_label ? `${v.emoji} ${v.label}` : v.label,
-        value: v.emoji && val.append_emoji_to_commit ? `${v.emoji} ${v.value}` : v.value,
       }))
       return { ...val, options }
     })
-   .refine(val => {
-     const options = val.options.map(v => ({value: v.value, emoji: v.emoji}) )
-     return options.some(o => val.append_emoji_to_commit ? `${o.emoji} ${o.value}` : `${o.value}`)
-   }, (val) => ({ message: `Type: initial_value "${val.initial_value}" must exist in options` })),
+    .refine(val => val.options.map(v => v.value).includes(val.initial_value)
+    , (val) => ({ message: `Type: initial_value "${val.initial_value}" must exist in options` })),
    commit_scope: z.object({
      enable: z.boolean().default(true),
      custom_scope: z.boolean().default(false),

--- a/src/zod-state.ts
+++ b/src/zod-state.ts
@@ -6,7 +6,7 @@ export const Config = z.object({
    check_status: z.boolean().default(true),
    commit_type: z.object({
      enable: z.boolean().default(true),
-     initial_value: z.string().default('✨ feat'),
+     initial_value: z.string().default('feat'),
      infer_type_from_branch: z.boolean().default(true),
      append_emoji_to_label: z.boolean().default(false),
      append_emoji_to_commit: z.boolean().default(false),


### PR DESCRIPTION
added two new configs, append_emoji_to_label and append_emoji_to_commit. Also added default emojis for all of the types. This will append the corresponding emoji to your label and/or value based on your config. default false.

Closes: #31