### PR TITLE
✨ feat(main): better-branch: disable user step

### DIFF
--- a/src/branch.ts
+++ b/src/branch.ts
@@ -14,7 +14,9 @@ main(load_setup(' better-branch '))
 async function main(config: z.infer<typeof Config>) {
     const branch_state = BranchState.parse({});
     const cache_user_name = get_user_from_cache()
+    const user_name_enabled = config.branch_user.enabled
     const user_name_required = config.branch_user.required
+    if(user_name_enabled || user_name_required) {
     const user_name = await p.text({
       message: `Type your git username ${user_name_required ? '' : OPTIONAL_PROMPT} ${CACHE_PROMPT}`.trim(),
       placeholder: '',
@@ -25,6 +27,9 @@ async function main(config: z.infer<typeof Config>) {
     })
     if (p.isCancel(user_name)) process.exit(0)
     branch_state.user = user_name?.replace(/\s+/g, '-')?.toLowerCase() ?? '';
+    } else {
+      branch_state.user = ''
+    }
     set_user_cache(branch_state.user)
 
     if (config.commit_type.enable) {

--- a/src/zod-state.ts
+++ b/src/zod-state.ts
@@ -76,6 +76,7 @@ export const Config = z.object({
    branch_post_commands: z.array(z.string()).default([]),
    branch_user: z.object({
      required: z.boolean().default(false),
+     enabled: z.boolean().default(true),
      separator: z.enum(['/', '-', '_']).default('/')
    }).default({}),
    branch_type: z.object({


### PR DESCRIPTION
### Why? 
It's annoying to have to confirm every time that I don't want to add my username to a branch name.

### What?
Skip user step in better-branchs when `config.branch_user.enabled` is `false`.