### PR TITLE
fix(main): #44 add underscore inference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-commits",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "better-commits",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@clack/core": "^0.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { simpleGit } from "simple-git"
 import { execSync } from 'child_process';
 import { z } from "zod";
 import { CommitState, Config } from './zod-state';
-import { load_setup, check_missing_stage, addNewLine, SPACE_TO_SELECT, REGEX_SLASH_TAG, REGEX_SLASH_NUM, REGEX_START_TAG, REGEX_START_NUM, OPTIONAL_PROMPT, clean_commit_title, COMMIT_FOOTER_OPTIONS, infer_type_from_branch, Z_FOOTER_OPTIONS, CUSTOM_SCOPE_KEY,  get_git_root } from './utils';
+import { load_setup, check_missing_stage, addNewLine, SPACE_TO_SELECT, REGEX_SLASH_TAG, REGEX_SLASH_NUM, REGEX_START_TAG, REGEX_START_NUM, OPTIONAL_PROMPT, clean_commit_title, COMMIT_FOOTER_OPTIONS, infer_type_from_branch, Z_FOOTER_OPTIONS, CUSTOM_SCOPE_KEY,  get_git_root, REGEX_SLASH_UND, REGEX_START_UND } from './utils';
 
 main(load_setup());
 
@@ -85,7 +85,14 @@ export async function main(config: z.infer<typeof Config>) {
   if (config.check_ticket.infer_ticket) {
     try {
       const branch = execSync('git branch --show-current', {stdio : 'pipe' }).toString();
-      const found: string[] = [branch.match(REGEX_SLASH_TAG), branch.match(REGEX_SLASH_NUM) , branch.match(REGEX_START_TAG), branch.match(REGEX_START_NUM)]
+      const found: string[] = [
+        branch.match(REGEX_SLASH_TAG),
+        branch.match(REGEX_SLASH_NUM),
+        branch.match(REGEX_SLASH_UND),
+        branch.match(REGEX_START_TAG),
+        branch.match(REGEX_START_NUM),
+        branch.match(REGEX_START_UND),
+      ]
       .filter(v => v != null)
       .map(v => v && v.length >= 2 ?  v[1] : '')
       if (found.length && found[0]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,12 +86,12 @@ export async function main(config: z.infer<typeof Config>) {
     try {
       const branch = execSync('git branch --show-current', {stdio : 'pipe' }).toString();
       const found: string[] = [
+        branch.match(REGEX_START_UND),
+        branch.match(REGEX_SLASH_UND),
         branch.match(REGEX_SLASH_TAG),
         branch.match(REGEX_SLASH_NUM),
-        branch.match(REGEX_SLASH_UND),
         branch.match(REGEX_START_TAG),
         branch.match(REGEX_START_NUM),
-        branch.match(REGEX_START_UND),
       ]
       .filter(v => v != null)
       .map(v => v && v.length >= 2 ?  v[1] : '')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,8 +16,8 @@ export const REGEX_SLASH_TAG = new RegExp(/\/(\w+-\d+)/)
 export const REGEX_START_TAG = new RegExp(/^(\w+-\d+)/)
 export const REGEX_SLASH_NUM = new RegExp(/\/(\d+)/)
 export const REGEX_START_NUM = new RegExp(/^(\d+)/)
-export const REGEX_START_UND = new RegExp(/^(\w+-[\w\d]+)_/)
-export const REGEX_SLASH_UND = new RegExp(/\/(\w+-[\w\d]+)_/)
+export const REGEX_START_UND = new RegExp(/^([A-Z]+-[\[a-zA-Z\]\d]+)_/)
+export const REGEX_SLASH_UND = new RegExp(/\/([A-Z]+-[\[a-zA-Z\]\d]+)_/)
 
 export const DEFAULT_TYPE_OPTIONS = [
     { value: 'feat', label: 'feat' , hint: 'A new feature', emoji: '✨'},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,9 @@ export const REGEX_SLASH_TAG = new RegExp(/\/(\w+-\d+)/)
 export const REGEX_START_TAG = new RegExp(/^(\w+-\d+)/)
 export const REGEX_SLASH_NUM = new RegExp(/\/(\d+)/)
 export const REGEX_START_NUM = new RegExp(/^(\d+)/)
+export const REGEX_START_UND = new RegExp(/^(\w+-[\w\d]+)_/)
+export const REGEX_SLASH_UND = new RegExp(/\/(\w+-[\w\d]+)_/)
+
 export const DEFAULT_TYPE_OPTIONS = [
     { value: 'feat', label: 'feat' , hint: 'A new feature', emoji: '✨'},
     { value: 'fix', label: 'fix' , hint: 'A bug fix', emoji: '🐛'},


### PR DESCRIPTION
added a check for TAG-letterswithnumbers_. This is to support clickup style ticket names. Explicitly checking for underscore prevents matching on something as simple as word-word

Closes: #44