### PR TITLE
feat(main): add configurable shell option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,9 @@ Any property can be removed from the config, it will be replaced by the default 
     },
     "branch_description": {
         "max_length": 70
+    },
+    "overrides": {
+        "shell": "path\to\shell"
     }
 }
 ```
@@ -280,3 +283,11 @@ You can add this badge to your repository to display that you're using a better-
 
 `TTY initialization failed: uv_tty_init returned EBADF (bad file descriptor)`. This may happen because you're running something like git-bash on Windows. Try another terminal/command-prompt or `winpty` to see if its still an issue.
 
+If your are having issues with multilines for commits on windows, you can override the shell via config.
+
+Example.
+```
+"overrides": {
+   "shell": "c:\\Program Files\\Git\\bin\\bash.exe"
+}
+```

--- a/readme.md
+++ b/readme.md
@@ -215,7 +215,7 @@ Any property can be removed from the config, it will be replaced by the default 
         "max_length": 70
     },
     "overrides": {
-        "shell": "path\to\shell"
+        "shell": "/bin/sh"
     }
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,7 +220,8 @@ export async function main(config: z.infer<typeof Config>) {
   } 
 
   try {      
-    const output = execSync(`git commit -m "${build_commit_string(commit_state, config, false)}"`).toString().trim();
+    const options = config.overrides.shell ? { shell: config.overrides.shell } : {}
+    const output = execSync(`git commit -m "${build_commit_string(commit_state, config, false)}"`, options).toString().trim();
     if (config.print_commit_output) p.log.info(output)
   } catch(err) {
     p.log.error('Something went wrong when committing: ' + err)

--- a/src/zod-state.ts
+++ b/src/zod-state.ts
@@ -91,6 +91,7 @@ export const Config = z.object({
    branch_description: z.object({
      max_length: z.number().positive().default(70)
    }).default({}),
+   overrides: z.object({ shell: z.string().optional() }).default({})
 }).default({})
 
 export const CommitState = z.object({


### PR DESCRIPTION
add configurable shell option to node child_process, windows machine have issues with new line using cmd.exe

Related to: https://github.com/Everduin94/better-commits/issues/47 that was closed but updating to the latest doesn't fix it. 
Due to windows, by default it uses `process.env.ComSpec` which targets `cmd.exe`, new line were cropped from the commit msg, so to resolve this a new config option is added `shell`.
eg, we can target bash
```
"shell": "c:\\Program Files\\Git\\bin\\bash.exe",
```
child_process should now uses bash to run git commit commands.