### PR TITLE
fix(branch): rev-parse in bare repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-commits",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "better-commits",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@clack/core": "^0.3.1",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -187,8 +187,19 @@ export function infer_type_from_branch(types: string[]): string {
   return found ?? "";
 }
 
+/*
+rev-parse will fail in a --bare repository root
+*/
 export function get_git_root(): string {
-  return execSync("git rev-parse --show-toplevel").toString().trim();
+  let path = ".";
+  try {
+    path = execSync("git rev-parse --show-toplevel").toString().trim();
+  } catch (err) {
+    p.log.warn(
+      "Could not find git root. If in a --bare repository, ignore this warning."
+    );
+  }
+  return path;
 }
 
 export function get_default_config_path(): string {


### PR DESCRIPTION
Running git rev-parse in a bare repository would cause better-branch to fail with cryptic errors. This uses the cwd as an alternative when git root can't be found.