### PR TITLE
fix(branch): worktree commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-commits",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "better-commits",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@clack/core": "^0.3.1",

--- a/readme.md
+++ b/readme.md
@@ -203,6 +203,8 @@ Better-commits (& better-branch) are highly flexible with sane defaults. These o
     "print_commit_output": true,
     "branch_pre_commands": [],
     "branch_post_commands": [],
+    "worktree_pre_commands": [],
+    "worktree_post_commands": [],
     "branch_user": {
         "enable": true,
         "required": false,
@@ -276,6 +278,8 @@ Better-commits (& better-branch) are highly flexible with sane defaults. These o
 | `print_commit_output`                      | If true pretty print commit preview                         |
 | `branch_pre_commands`                      | Array of shell commands to run before branching             |
 | `branch_post_commands`                     | Array of shell commands to run after branching              |
+| `worktree_pre_commands`                    | Array of shell commands to run before creating worktree     |
+| `worktree_post_commands`                   | Array of shell commands to run after creating worktree      |
 | `branch_user.enable`                       | If enabled include user name                                |
 | `branch_user.required`                     | If enabled require user name                                |
 | `branch_user.separator`                    | Branch delimeter                                            |
@@ -330,7 +334,7 @@ Optionally configure pre and post checkout commands, for example:
 - run `npm install` before branching
 - run `npm run dev` after branching
 
-See *branch_pre_commands* and *branch_post_commands* in default config.
+See *branch_pre_commands* and *branch_post_commands* in default config. (or *worktree_pre_commands* and *worktree_post_commands* for creating worktrees)
 
 ## 🌌 Mildly Interesting
 

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -91,7 +91,11 @@ async function main(config: z.infer<typeof Config>) {
   branch_state.description =
     description?.replace(/\s+/g, "-")?.toLowerCase() ?? "";
 
-  config.branch_pre_commands.forEach((command) => {
+  const pre_commands =
+    checkout_type === "worktree"
+      ? config.worktree_pre_commands
+      : config.branch_pre_commands;
+  pre_commands.forEach((command) => {
     try {
       execSync(command, { stdio: "inherit" });
     } catch (err) {
@@ -142,7 +146,11 @@ async function main(config: z.infer<typeof Config>) {
     }
   }
 
-  config.branch_post_commands.forEach((command) => {
+  const post_commands =
+    checkout_type === "worktree"
+      ? config.worktree_post_commands
+      : config.branch_post_commands;
+  post_commands.forEach((command) => {
     try {
       execSync(command, { stdio: "inherit" });
     } catch (err) {

--- a/src/zod-state.ts
+++ b/src/zod-state.ts
@@ -124,6 +124,8 @@ export const Config = z
     print_commit_output: z.boolean().default(true),
     branch_pre_commands: z.array(z.string()).default([]),
     branch_post_commands: z.array(z.string()).default([]),
+    worktree_pre_commands: z.array(z.string()).default([]),
+    worktree_post_commands: z.array(z.string()).default([]),
     branch_user: z
       .object({
         enable: z.boolean().default(true),


### PR DESCRIPTION
Separate branch and worktree pre/post commands. Some operations that make sense for branches (like git stash), will throw an error in the root of a bare repository (like when working with worktrees). Increasing the granularity of the configuration tracks with previous decisions and helps avoid issues like this.