### PR TITLE
feat(main): #56 remove simple-git

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "scripts": {
     "start": "jiti ./src/index.ts",
-    "parse": "jiti ./src/git.ts",
     "branch": "jiti ./src/branch.ts",
     "init": "jiti ./src/init.ts",
     "build": "tsup ./src/",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "@clack/prompts": "^0.6.2",
     "configstore": "^5.0.1",
     "picocolors": "^1.0.0",
-    "simple-git": "^3.16.1",
     "zod": "^3.21.3",
     "zod-validation-error": "^1.0.1"
   },
   "scripts": {
     "start": "jiti ./src/index.ts",
+    "parse": "jiti ./src/git.ts",
     "branch": "jiti ./src/branch.ts",
     "init": "jiti ./src/init.ts",
     "build": "tsup ./src/",

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,57 @@
+#! /usr/bin/env node
+import { execSync } from "child_process";
+import * as p from "@clack/prompts";
+import color from "picocolors";
+
+const porcelain_states = ["M", "T", "R", "D", "A", "C"];
+
+export function git_status(): { index: string[]; work_tree: string[] } {
+  let status = "";
+  try {
+    status = execSync("git status --porcelain", { stdio: "pipe" }).toString();
+  } catch (err) {
+    p.log.error(color.red("Failed to git status"));
+    return { index: [], work_tree: [] };
+  }
+
+  const lines = status.split("\n");
+  const work_tree: string[] = [];
+  const index: string[] = [];
+  lines.forEach((v) => {
+    const line = v.trimEnd();
+    if (!line) return;
+
+    const path_plus_file = line.substring(2).trim();
+    const first_char = line.charAt(0).trim();
+    const second_char = line.charAt(1).trim();
+
+    // Untracked, always dirty
+    if (first_char === "?" || second_char === "?") {
+      work_tree.push(path_plus_file);
+    }
+
+    if (porcelain_states.includes(first_char)) {
+      index.push(path_plus_file);
+    }
+
+    if (porcelain_states.includes(second_char)) {
+      work_tree.push(path_plus_file);
+    }
+  });
+
+  return { index, work_tree };
+}
+
+export function git_add(files: string[]) {
+  const space_delimited_files = files.join(" ");
+  if (space_delimited_files) {
+    try {
+      execSync(`git add ${space_delimited_files}`, {
+        stdio: "pipe",
+      }).toString();
+      p.log.success(color.green("Changes successfully staged"));
+    } catch (err) {
+      p.log.error(color.red("Failed to stage changes"));
+    }
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import { homedir } from "os";
-import { StatusResult } from "simple-git";
 import { z } from "zod";
 import color from "picocolors";
 import { execSync } from "child_process";
@@ -10,6 +9,9 @@ import { Config } from "./zod-state";
 
 export const CONFIG_FILE_NAME = ".better-commits.json";
 export const SPACE_TO_SELECT = `${color.dim("(<space> to select)")}`;
+export const A_FOR_ALL = `${color.dim(
+  "(<space> to select, <a> to select all)"
+)}`;
 export const OPTIONAL_PROMPT = `${color.dim("(optional)")}`;
 export const CACHE_PROMPT = `${color.dim("(value will be saved)")}`;
 export const REGEX_SLASH_TAG = new RegExp(/\/(\w+-\d+)/);
@@ -204,12 +206,6 @@ export function get_git_root(): string {
 
 export function get_default_config_path(): string {
   return homedir() + "/" + CONFIG_FILE_NAME;
-}
-
-export function check_missing_stage(stats: StatusResult): string[] {
-  return stats.files
-    .filter((f) => f.index.trim() === "" || f.index === "?")
-    .map((f) => f.path);
 }
 
 export function addNewLine(arr: string[], i: number) {


### PR DESCRIPTION
Replace simple-git with custom status parser. This should reduce the size of the project by about 38%. This also fixes a bug where no files were found as staged, or when files differed in the index and work tree. Note, the issue mentions this bug was caused by simple-git. That's not true. It was my own code (surprise surprise). However, the project doesn't need all of what simple-git is.

@davidsneighbour - fixes the rename issue in #60 

![rename](https://github.com/Everduin94/better-commits/assets/14320878/b5e798dd-0573-40ab-8e5b-e03fb935857d)



Closes: #56, #60