### PR TITLE
docs: correct typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@
 </h3>
 
 <p align="center">
-A CLI for writing better commits, following the conventional commit guidelines.
+A CLI for writing better commits, following the conventional commits guidelines.
 </p>
 
 

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@
 </h3>
 
 <p align="center">
-A CLI for writing better commits, following the conventional commits guidelines.
+A CLI for writing better commits, following the conventional commits specification.
 </p>
 
 


### PR DESCRIPTION
add "s" to "conventional commit" at first line of docs