### PR TITLE
feat(main): #84 verify the override shell path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,28 @@ import { execSync } from 'child_process';
 import { chdir } from "process";
 import { z } from "zod";
 import { CommitState, Config } from './zod-state';
-import { load_setup,  addNewLine, SPACE_TO_SELECT, REGEX_SLASH_TAG, REGEX_SLASH_NUM, REGEX_START_TAG, REGEX_START_NUM, OPTIONAL_PROMPT, clean_commit_title, COMMIT_FOOTER_OPTIONS, infer_type_from_branch, Z_FOOTER_OPTIONS, CUSTOM_SCOPE_KEY,  get_git_root, REGEX_SLASH_UND, REGEX_START_UND } from './utils';
+import { load_setup,  addNewLine, SPACE_TO_SELECT, REGEX_SLASH_TAG, REGEX_SLASH_NUM, REGEX_START_TAG, REGEX_START_NUM, OPTIONAL_PROMPT, clean_commit_title, COMMIT_FOOTER_OPTIONS, infer_type_from_branch, Z_FOOTER_OPTIONS, CUSTOM_SCOPE_KEY,  get_git_root, REGEX_SLASH_UND, REGEX_START_UND, WINDOW_DEFAULT_SHELLL_WARNING } from './utils';
 import { git_add, git_status } from './git';
+import fs from 'fs';
 
 main(load_setup());
 
 export async function main(config: z.infer<typeof Config>) {
+
+      
+  if(config.overrides.shell && !fs.existsSync(config.overrides.shell)) {
+    p.log.error(
+      `Shell override path does not exist: "${config.overrides.shell}"`
+    )
+    const is_continue_with_default_shell = await p.confirm({
+      message: `Continue with default shell?
+       ${WINDOW_DEFAULT_SHELLL_WARNING}`
+    }) as boolean;
+    is_continue_with_default_shell ? config.overrides.shell = '' : process.exit(0)
+    if (p.isCancel(is_continue_with_default_shell)) process.exit(0)
+  }
+
+
   let commit_state = CommitState.parse({})
   chdir(get_git_root());
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,9 @@ export const A_FOR_ALL = `${color.dim(
 )}`;
 export const OPTIONAL_PROMPT = `${color.dim("(optional)")}`;
 export const CACHE_PROMPT = `${color.dim("(value will be saved)")}`;
+export const WINDOW_DEFAULT_SHELLL_WARNING = `${color.dim(
+  "(using window default shell can cause issues with multiple lines)"
+)}`;
 export const REGEX_SLASH_TAG = new RegExp(/\/(\w+-\d+)/);
 export const REGEX_START_TAG = new RegExp(/^(\w+-\d+)/);
 export const REGEX_START_UND = new RegExp(/^([A-Z]+-[\[a-zA-Z\]\d]+)_/);


### PR DESCRIPTION
In case  `better-commits` is installed in repository scope, fixed override shell path for users work with multi OS (window, linux) can lead to issue. 
So I add option to warning not existed path and still continue with default shell.