### PR TITLE
feat(util): #84 merge partial global props 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,8 +65,9 @@ Your first time running `better-commits`, a default config will be generated in 
 ### Repository
 
 To create a **repository-specific config**, navigate to the root of your project.
-- run `better-commits-init`
+- Run `better-commits-init`
 - This will create a default config named `.better-commits.json`
+- Properties such as `confirm_with_editor` and `overrides` will prefer the global config
 
 ### Options
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -162,8 +162,8 @@ export function load_setup(
     const repo_config = read_config_from_path(root_path);
     return global_config ? {
       ...repo_config,
-      overrides: global_config.overrides ?? repo_config.overrides,
-      confirm_with_editor: global_config.confirm_with_editor ?? repo_config.confirm_with_editor
+      overrides: global_config.overrides.shell ? global_config.overrides : repo_config.overrides,
+      confirm_with_editor: global_config.confirm_with_editor
     } : repo_config
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,18 +148,26 @@ export function load_setup(
   console.clear();
   p.intro(`${color.bgCyan(color.black(cli_name))}`);
 
+  let global_config = null
+  const home_path = get_default_config_path();
+  if (fs.existsSync(home_path)) {
+    p.log.step("Found global config");
+    global_config = read_config_from_path(home_path);
+  }
+
   const root = get_git_root();
   const root_path = `${root}/${CONFIG_FILE_NAME}`;
   if (fs.existsSync(root_path)) {
     p.log.step("Found repository config");
-    return read_config_from_path(root_path);
+    const repo_config = read_config_from_path(root_path);
+    return global_config ? {
+      ...repo_config,
+      overrides: global_config.overrides ?? repo_config.overrides,
+      confirm_with_editor: global_config.confirm_with_editor ?? repo_config.confirm_with_editor
+    } : repo_config
   }
 
-  const home_path = get_default_config_path();
-  if (fs.existsSync(home_path)) {
-    p.log.step("Found global config");
-    return read_config_from_path(home_path);
-  }
+  if (global_config) return global_config
 
   const default_config = Config.parse({});
   p.log.step(


### PR DESCRIPTION
This PR changes the flow when pulling configurations. Global will always be pulled, and then merge specific properties into the repository config if it exists.

Closes: https://github.com/Everduin94/better-commits/issues/84