### PR TITLE
feat(options): New option for ticket title

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -305,7 +305,7 @@ Expand to see explanations and possible values
 | `check_ticket.add_to_title`                | If true add ticket to title                                 |
 | `check_ticket.append_hashtag`              | **Deprecated**: see prepend_hashtag                         |
 | `check_ticket.prepend_hashtag`             | "Never" (default), "Prompt", or "Always"                    |
-| `check_ticket.title_position`              | "start" (of description) (default), "end", "before-colon"   |
+| `check_ticket.title_position`              | "start" (of description) (default), "end", "before-colon", "beginning" (of the entire commit title)   |
 | `check_ticket.surround`                    | "" (default), "[]", "()", "{}" - Wraps ticket in title      |
 | `commit_title.max_size`                    | Max size of title including scope, type, etc...             |
 | `commit_body.enable`                       | If true include body                                        |

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,6 +268,11 @@ function build_commit_string(commit_state: z.infer<typeof CommitState>,
     const close_token = surround.charAt(1);
     title_ticket = `${open_token}${commit_state.ticket}${close_token}` 
   }
+  
+  const position_beginning = config.check_ticket.title_position === 'beginning';
+  if (title_ticket && config.check_ticket.add_to_title && position_beginning) {
+    commit_string = `${colorize ? color.magenta(title_ticket) : title_ticket} ${commit_string}`;
+  }
 
   const position_before_colon = config.check_ticket.title_position === "before-colon"
   if (title_ticket && config.check_ticket.add_to_title && position_before_colon) {
@@ -343,4 +348,3 @@ function build_commit_string(commit_state: z.infer<typeof CommitState>,
 
   return commit_string;
 }
-

--- a/src/zod-state.ts
+++ b/src/zod-state.ts
@@ -99,7 +99,7 @@ export const Config = z
         append_hashtag: z.boolean().default(false),
         prepend_hashtag: z.enum(['Never', 'Always', 'Prompt']).default("Never"),
         surround: z.enum(["", "()", "[]", "{}"]).default(""),
-        title_position: z.enum(["start", "end", "before-colon"]).default("start"),
+        title_position: z.enum(["start", "end", "before-colon", "beginning"]).default("start"),
       })
       .default({}),
     commit_title: z


### PR DESCRIPTION
**Added a new option:**
`check_ticket.title_position = "beginning"`

> Will place the ticket number at the beginning of the entire commit message.

**Example:**
`[TICKET-123] feat(app): New option`

I don't know how useful this is for other people, but our project uses this commit structure and it would be very convenient to use `better-commits` in our project for standardization.