### PR TITLE
add maxItems option to scope prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "bin": {
     "better-commits-init": "./dist/init.js",
-    "better-commits": "./dist/sindex.js",
+    "better-commits": "./dist/index.js",
     "better-branch": "./dist/branch.js",
     "bcommits": "./dist/index.js",
     "git-bc": "./dist/index.js"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "bin": {
     "better-commits-init": "./dist/init.js",
-    "better-commits": "./dist/index.js",
+    "better-commits": "./dist/sindex.js",
     "better-branch": "./dist/branch.js",
     "bcommits": "./dist/index.js",
     "git-bc": "./dist/index.js"
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@clack/core": "^0.3.1",
-    "@clack/prompts": "^0.6.2",
+    "@clack/prompts": "^0.7.0",
     "configstore": "^5.0.1",
     "picocolors": "^1.0.0",
     "valibot": "^0.30.0"

--- a/readme.md
+++ b/readme.md
@@ -168,6 +168,7 @@ Better-commits (& better-branch) are highly flexible with sane defaults. These o
     "enable": true,
     "custom_scope": false,
     "initial_value": "app",
+    "max_items": Infinity
     "options": [
       {
         "value": "app",
@@ -292,6 +293,7 @@ Expand to see explanations and possible values
 | `commit_scope.enable`                      | If true include commit scope                                                                        |
 | `commit_scope.custom_scope`                | If true allow custom scope at run-time                                                              |
 | `commit_scope.initial_value`               | Default commit scope selected                                                                       |
+| `commit_scope.max_items`                   | Maximum number of scope displayed on the screen                                                     |
 | `commit_scope.options.value`               | Commit scope value                                                                                  |
 | `commit_scope.options.label`               | Commit scope label                                                                                  |
 | `check_ticket.infer_ticket`                | If true infer ticket from branch name                                                               |

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,7 @@ Better-commits (& better-branch) are highly flexible with sane defaults. These o
   "commit_type": {
     "enable": true,
     "initial_value": "feat",
+    "max_items": Infinity,
     "infer_type_from_branch": true,
     "append_emoji_to_label": false,
     "append_emoji_to_commit": false,
@@ -282,6 +283,7 @@ Expand to see explanations and possible values
 | `check_status`                             | If true run interactive `git status`                                                                |
 | `commit_type.enable`                       | If true include commit type                                                                         |
 | `commit_type.initial_value`                | Initial selection of commit type                                                                    |
+| `commit_type.max_items`                    | Maximum number of type displayed on the screen                                                      |
 | `commit_type.infer_type_from_branch`       | If true infer type from branch name                                                                 |
 | `commit_type.append_emoji_to_label`        | If true append emoji to prompt                                                                      |
 | `commit_type.append_emoji_to_commit`       | If true append emoji to commit                                                                      |

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,7 @@ export async function main(config: Output<typeof Config>) {
     const commit_type = await p.select({
       message,
       initialValue: initial_value,
+      maxItems: config.commit_type.max_items,
       options: config.commit_type.options,
     });
     if (p.isCancel(commit_type)) process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ export async function main(config: Output<typeof Config>) {
     let commit_scope = await p.select({
       message: "Select a commit scope",
       initialValue: config.commit_scope.initial_value,
+      maxItems: config.commit_scope.max_items,
       options: config.commit_scope.options,
     });
     if (p.isCancel(commit_scope)) process.exit(0);

--- a/src/valibot-state.ts
+++ b/src/valibot-state.ts
@@ -65,6 +65,7 @@ export const Config = v.object({
         {
           enable: v.optional(v.boolean(), true),
           custom_scope: v.optional(v.boolean(), false),
+          max_items: v.optional(v.number(), Infinity),
           initial_value: v.optional(v.string(), "app"),
           options: v.optional(
             v.array(

--- a/src/valibot-state.ts
+++ b/src/valibot-state.ts
@@ -18,6 +18,7 @@ export const Config = v.object({
         {
           enable: v.optional(v.boolean(), true),
           initial_value: v.optional(v.string(), "feat"),
+          max_items: v.optional(v.number(), Infinity),
           infer_type_from_branch: v.optional(v.boolean(), true),
           append_emoji_to_label: v.optional(v.boolean(), false),
           append_emoji_to_commit: v.optional(v.boolean(), false),


### PR DESCRIPTION
Fixed glitch on small height screen for long scopes list. Base on @clack/prompts@0.7.0 via https://github.com/natemoo-re/clack/pull/174