### PR TITLE
fix(branch): default branch ticket sep

### DIFF
--- a/src/valibot-state.ts
+++ b/src/valibot-state.ts
@@ -189,7 +189,7 @@ export const Config = v.object({
     v.object({
       enable: v.optional(v.boolean(), true),
       required: v.optional(v.boolean(), false),
-      separator: v.optional(v.picklist(["/", "-", "_"]), "/"),
+      separator: v.optional(v.picklist(["/", "-", "_"]), "-"),
     }),
     {},
   ),


### PR DESCRIPTION
During the valibot refactor, the wrong separator was set as the default for branch_ticket