### PR TITLE
feat(main): #109 git-dir and work-tree

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@
 A CLI for writing better commits, following the conventional commits specification.
 </p>
 
-https://github.com/Everduin94/better-commits/assets/14320878/8fb15d46-17c4-4e5d-80d9-79abe0a2a00a
+<https://github.com/Everduin94/better-commits/assets/14320878/8fb15d46-17c4-4e5d-80d9-79abe0a2a00a>
 
 ## ✨ Features
 
@@ -95,12 +95,13 @@ Better-commits (& better-branch) are highly flexible with sane defaults. These o
     "infer_type_from_branch": true,
     "append_emoji_to_label": false,
     "append_emoji_to_commit": false,
+    "emoji_commit_position": "Start",
     "options": [
       {
         "value": "feat",
         "label": "feat",
         "hint": "A new feature",
-        "emoji": "✨",
+        "emoji": "🌟",
         "trailer": "Changelog: feature"
       },
       {
@@ -259,7 +260,7 @@ Better-commits (& better-branch) are highly flexible with sane defaults. These o
 </details>
 
 > [!NOTE]<br>
-> Some properties allow a set of specifc string values
+> Some properties allow a set of specific string values
 >
 > - See _config file explanations_ for possible values
 
@@ -287,6 +288,7 @@ Expand to see explanations and possible values
 | `commit_type.infer_type_from_branch`       | If true infer type from branch name                                                                 |
 | `commit_type.append_emoji_to_label`        | If true append emoji to prompt                                                                      |
 | `commit_type.append_emoji_to_commit`       | If true append emoji to commit                                                                      |
+| `commit_type.emoji_commit_position`        | Emoji position, "Start" (default) or "After-Colon"                                                  |
 | `commit_type.options.value`                | Commit type prompt value                                                                            |
 | `commit_type.options.label`                | Commit type prompt label                                                                            |
 | `commit_type.options.hint`                 | Commit type inline hint (like this)                                                                 |
@@ -432,6 +434,16 @@ You can add this badge to your repository to display that you're using a better-
 | Markdown                                                                                                                                                                                                          | Result                                                                                                                                                                                                          |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `[![better commits is enabled](https://img.shields.io/badge/better--commits-enabled?style=for-the-badge&logo=git&color=a6e3a1&logoColor=D9E0EE&labelColor=302D41)](https://github.com/Everduin94/better-commits)` | [![better commits is enabled](https://img.shields.io/badge/better--commits-enabled?style=for-the-badge&logo=git&color=a6e3a1&logoColor=D9E0EE&labelColor=302D41)](https://github.com/Everduin94/better-commits) |
+
+### Git Arguments
+
+You can pass arguments to `git` through `better-commits` like so:
+
+```sh
+better-commits --git-dir="$HOME/.config" --work-tree="$HOME"
+```
+
+A practical example of this would be managing dotfiles, as described in this [Atlassian Article](https://www.atlassian.com/git/tutorials/dotfiles)
 
 ---
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,0 +1,12 @@
+class Flags {
+  #git_args: string = "";
+  constructor() {}
+  get git_args() {
+    return this.#git_args;
+  }
+  set git_args(value: string) {
+    this.#git_args = value;
+  }
+}
+
+export const flags = new Flags();

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -18,6 +18,7 @@ import {
   OPTIONAL_PROMPT,
   load_setup,
 } from "./utils";
+import { flags } from "./args";
 
 main(load_setup(" better-branch "));
 
@@ -126,7 +127,7 @@ async function main(config: Output<typeof Config>) {
   const branch_flag = verify_branch_name(branch_name);
   if (checkout_type === "branch") {
     try {
-      execSync(`git checkout ${branch_flag} ${branch_name}`, {
+      execSync(`git ${flags.git_args} checkout ${branch_flag} ${branch_name}`, {
         stdio: "inherit",
       });
       p.log.info(

--- a/src/git.ts
+++ b/src/git.ts
@@ -2,15 +2,18 @@
 import { execSync } from "child_process";
 import * as p from "@clack/prompts";
 import color from "picocolors";
+import { flags } from "./args";
 
 const porcelain_states = ["M", "T", "R", "D", "A", "C"];
 
 export function git_status(): { index: string[]; work_tree: string[] } {
   let status = "";
   try {
-    status = execSync("git status --porcelain", { stdio: "pipe" }).toString();
+    status = execSync(`git ${flags.git_args} status --porcelain`, {
+      stdio: "pipe",
+    }).toString();
   } catch (err) {
-    p.log.error(color.red("Failed to git status"));
+    p.log.error(color.red("Failed to git status" + err));
     return { index: [], work_tree: [] };
   }
 
@@ -46,7 +49,7 @@ export function git_add(files: string[]) {
   const space_delimited_files = files.join(" ");
   if (space_delimited_files) {
     try {
-      execSync(`git add ${space_delimited_files}`, {
+      execSync(`git ${flags.git_args} add ${space_delimited_files}`, {
         stdio: "pipe",
       }).toString();
       p.log.success(color.green("Changes successfully staged"));

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
 } from "./utils";
 import { git_add, git_status } from "./git";
 import { CUSTOM_SCOPE_KEY, V_FOOTER_OPTIONS } from "./valibot-consts";
+import { flags } from "./args";
 
 main(load_setup());
 
@@ -124,7 +125,7 @@ export async function main(config: Output<typeof Config>) {
 
   if (config.check_ticket.infer_ticket) {
     try {
-      const branch = execSync("git branch --show-current", {
+      const branch = execSync(`git ${flags.git_args} branch --show-current`, {
         stdio: "pipe",
       }).toString();
       const found: string[] = [
@@ -282,7 +283,7 @@ export async function main(config: Output<typeof Config>) {
       ? `--trailer="${commit_state.trailer}"`
       : "";
     execSync(
-      `git commit -m "${build_commit_string(commit_state, config, false, true, false)}" ${trailer} --edit`,
+      `git ${flags.git_args} commit -m "${build_commit_string(commit_state, config, false, true, false)}" ${trailer} --edit`,
       options,
     );
     process.exit(0);
@@ -313,7 +314,7 @@ export async function main(config: Output<typeof Config>) {
       ? `--trailer="${commit_state.trailer}"`
       : "";
     const output = execSync(
-      `git commit -m "${build_commit_string(commit_state, config, false, true, false)}" ${trailer}`,
+      `git ${flags.git_args} commit -m "${build_commit_string(commit_state, config, false, true, false)}" ${trailer}`,
       options,
     )
       .toString()

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,17 @@ export async function main(config: Output<typeof Config>) {
     }
   }
 
+  const value_to_data: Record<string, { emoji: string; trailer: string }> =
+    config.commit_type.options.reduce(
+      (acc, curr) => ({
+        ...acc,
+        [curr.value]: {
+          emoji: curr.emoji ?? "",
+          trailer: curr.trailer ?? "",
+        },
+      }),
+      {},
+    );
   if (config.commit_type.enable) {
     let message = "Select a commit type";
     let initial_value = config.commit_type.initial_value;
@@ -81,17 +92,6 @@ export async function main(config: Output<typeof Config>) {
         initial_value = type_from_branch;
       }
     }
-    const value_to_data: Record<string, { emoji: string; trailer: string }> =
-      config.commit_type.options.reduce(
-        (acc, curr) => ({
-          ...acc,
-          [curr.value]: {
-            emoji: curr.emoji ?? "",
-            trailer: curr.trailer ?? "",
-          },
-        }),
-        {},
-      );
     const commit_type = await p.select({
       message,
       initialValue: initial_value,
@@ -100,9 +100,11 @@ export async function main(config: Output<typeof Config>) {
     });
     if (p.isCancel(commit_type)) process.exit(0);
     commit_state.trailer = value_to_data[commit_type].trailer;
-    commit_state.type = config.commit_type.append_emoji_to_commit
-      ? `${value_to_data[commit_type].emoji} ${commit_type}`.trim()
-      : commit_type;
+    commit_state.type =
+      config.commit_type.append_emoji_to_commit &&
+      config.commit_type.emoji_commit_position === "Start"
+        ? `${value_to_data[commit_type].emoji} ${commit_type}`.trim()
+        : commit_type;
   }
 
   if (config.commit_scope.enable) {
@@ -193,7 +195,13 @@ export async function main(config: Output<typeof Config>) {
     },
   });
   if (p.isCancel(commit_title)) process.exit(0);
-  commit_state.title = clean_commit_title(commit_title);
+  let commit_title_with_emoji = commit_title;
+  if (
+    config.commit_type.append_emoji_to_commit &&
+    config.commit_type.emoji_commit_position === "After-Colon"
+  )
+    commit_title_with_emoji = `${value_to_data[commit_state.type].emoji} ${commit_title}`;
+  commit_state.title = clean_commit_title(commit_title_with_emoji);
 
   if (config.commit_body.enable) {
     const commit_body = await p.text({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,8 @@ import color from "picocolors";
 import { Output, ValiError, parse } from "valibot";
 import { Config } from "./valibot-state";
 import { V_BRANCH_ACTIONS } from "./valibot-consts";
+import { argv } from "process";
+import { flags } from "./args";
 
 export const CONFIG_FILE_NAME = ".better-commits.json";
 export const SPACE_TO_SELECT = `${color.dim("(<space> to select)")}`;
@@ -60,6 +62,8 @@ export function load_setup(
 ): Output<typeof Config> {
   console.clear();
   p.intro(`${color.bgCyan(color.black(cli_name))}`);
+
+  set_non_configuration_arguments();
 
   let global_config = null;
   const home_path = get_default_config_path();
@@ -125,7 +129,7 @@ function validate_config(config: Output<typeof Config>): Output<typeof Config> {
 export function infer_type_from_branch(types: string[]): string {
   let branch = "";
   try {
-    branch = execSync("git branch --show-current", {
+    branch = execSync(`git ${flags.git_args} branch --show-current`, {
       stdio: "pipe",
     }).toString();
   } catch (err) {
@@ -152,7 +156,9 @@ rev-parse will fail in a --bare repository root
 export function get_git_root(): string {
   let path = ".";
   try {
-    path = execSync("git rev-parse --show-toplevel").toString().trim();
+    path = execSync(`git ${flags.git_args} rev-parse --show-toplevel`)
+      .toString()
+      .trim();
   } catch (err) {
     p.log.warn(
       "Could not find git root. If in a --bare repository, ignore this warning.",
@@ -176,4 +182,8 @@ export function clean_commit_title(title: string): string {
     return title_trimmed.substring(0, title_trimmed.length - 1).trim();
   }
   return title.trim();
+}
+
+function set_non_configuration_arguments() {
+  flags.git_args = `${argv[2] ?? ""} ${argv[3] ?? ""}`.trim();
 }

--- a/src/valibot-consts.ts
+++ b/src/valibot-consts.ts
@@ -51,7 +51,7 @@ export const DEFAULT_TYPE_OPTIONS = [
     value: "feat",
     label: "feat",
     hint: "A new feature",
-    emoji: "✨",
+    emoji: "🌟",
     trailer: "Changelog: feature",
   },
   {

--- a/src/valibot-state.ts
+++ b/src/valibot-state.ts
@@ -22,6 +22,10 @@ export const Config = v.object({
           infer_type_from_branch: v.optional(v.boolean(), true),
           append_emoji_to_label: v.optional(v.boolean(), false),
           append_emoji_to_commit: v.optional(v.boolean(), false),
+          emoji_commit_position: v.optional(
+            v.picklist(["Start", "After-Colon"]),
+            "Start",
+          ),
           options: v.optional(
             v.array(
               v.object({
@@ -83,6 +87,7 @@ export const Config = v.object({
           v.custom(
             (val) => {
               const options = val.options.map((v) => v.value);
+              if (val.custom_scope) options.push(CUSTOM_SCOPE_KEY);
               return options.includes(val.initial_value);
             },
             (val) => {


### PR DESCRIPTION
Added the ability to pass git-dir and work-tree to the git command. This enables setting up your dotfiles with bare repositories (using better-commits) as seen here: https://www.atlassian.com/git/tutorials/dotfiles

Testing: `npm i -g better-commits@1.15.8-feature-branch`

Examples
- **With args:** `better-commits --git-dir="$HOME/.cfg" --work-tree="$HOME"`
- **Without args:** `better-commits`

Closes: #109