### PR TITLE
fix(main): #113 inherit commit output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -331,7 +331,7 @@ export async function main(config: Output<typeof Config>) {
   } catch (err) {
     p.log.error("Something went wrong when committing: " + err);
   }
-  p.log.success("Commit Completed");
+  p.log.success("Commit Complete");
 }
 
 function build_commit_string(


### PR DESCRIPTION
Update git commit to use stdio inherit. Enables asynchronous printing of commit hook output.

![2025-02-02_08-40](https://github.com/user-attachments/assets/9fc98369-9478-41c6-bcad-264e827590fb)

Closes: #113