### PR TITLE
feat(util): #117 cache last value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ Better-commits (& better-branch) are highly flexible with sane defaults. These o
   "commit_type": {
     "enable": true,
     "initial_value": "feat",
-    "max_items": Infinity,
+    "max_items": 20,
     "infer_type_from_branch": true,
     "append_emoji_to_label": false,
     "append_emoji_to_commit": false,
@@ -170,7 +170,7 @@ Better-commits (& better-branch) are highly flexible with sane defaults. These o
     "enable": true,
     "custom_scope": false,
     "initial_value": "app",
-    "max_items": Infinity
+    "max_items": 20
     "options": [
       {
         "value": "app",
@@ -219,6 +219,7 @@ Better-commits (& better-branch) are highly flexible with sane defaults. These o
     "add_exclamation_to_title": true
   },
   "confirm_commit": true,
+  "cache_last_value": true,
   "confirm_with_editor": false,
   "print_commit_output": true,
   "branch_pre_commands": [],
@@ -316,6 +317,7 @@ Expand to see explanations and possible values
 | `breaking_change.add_exclamation_to_title` | If true adds exclamation mark to title for breaking changes                                         |
 | `confirm_commit`                           | If true manually confirm commit at end                                                              |
 | `confirm_with_editor`                      | Confirm / Edit commit with $GIT_EDITOR / $EDITOR                                                    |
+| `cache_last_value`                         | Reuse last prompt value after cancel                                                                |
 | `print_commit_output`                      | If true pretty print commit preview                                                                 |
 | `overrides.shell`                          | Override default shell, useful for windows users                                                    |
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import { Config } from "./valibot-state";
 import { V_BRANCH_ACTIONS } from "./valibot-consts";
 import { argv } from "process";
 import { flags } from "./args";
+import Configstore from "configstore";
 
 export const CONFIG_FILE_NAME = ".better-commits.json";
 export const SPACE_TO_SELECT = `${color.dim("(<space> to select)")}`;
@@ -56,6 +57,12 @@ export const BRANCH_ACTION_OPTIONS: {
   { value: "worktree", label: "Worktree" },
 ];
 
+export const NOOP_PROMPT_CACHE = {
+  get: () => "",
+  set: (key: string, value: string) => {},
+  clear: () => {},
+} as unknown as Configstore;
+
 /* LOAD */
 export function load_setup(
   cli_name = " better-commits ",
@@ -84,6 +91,7 @@ export function load_setup(
             ? global_config.overrides
             : repo_config.overrides,
           confirm_with_editor: global_config.confirm_with_editor,
+          cache_last_value: global_config.cache_last_value,
         }
       : repo_config;
   }
@@ -186,4 +194,29 @@ export function clean_commit_title(title: string): string {
 
 function set_non_configuration_arguments() {
   flags.git_args = `${argv[2] ?? ""} ${argv[3] ?? ""}`.trim();
+}
+
+export function get_value_from_cache(
+  config_store: Configstore,
+  key: string,
+): string {
+  try {
+    return config_store.get(key) ?? "";
+  } catch (err) {
+    /* Silent error - return empty string */
+  }
+
+  return "";
+}
+
+export function set_value_cache(
+  config_store: Configstore,
+  key: string,
+  value: string,
+): void {
+  try {
+    config_store.set(key, value);
+  } catch (err) {
+    /* Silent error - return empty string */
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -203,7 +203,9 @@ export function get_value_from_cache(
   try {
     return config_store.get(key) ?? "";
   } catch (err) {
-    /* Silent error - return empty string */
+    p.log.warn(
+      `Could not access ${key} from cache. Check that "~/.config" exists. Set "cache_last_value" to false to disable.`,
+    );
   }
 
   return "";
@@ -217,6 +219,8 @@ export function set_value_cache(
   try {
     config_store.set(key, value);
   } catch (err) {
-    /* Silent error - return empty string */
+    p.log.warn(
+      `Could not access ${key} from cache. Check that "~/.config" exists. Set "cache_last_value" to false to disable.`,
+    );
   }
 }

--- a/src/valibot-state.ts
+++ b/src/valibot-state.ts
@@ -162,6 +162,7 @@ export const Config = v.object({
     }),
     {},
   ),
+  cache_last_value: v.optional(v.boolean(), true),
   confirm_with_editor: v.optional(v.boolean(), false),
   confirm_commit: v.optional(v.boolean(), true),
   print_commit_output: v.optional(v.boolean(), true),


### PR DESCRIPTION
Added config "cache_last_value", default . When re-running better-commits, will use values from the previous run.

Closes: #117