### PR TITLE
fix(main): #120 escape backticks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -449,7 +449,8 @@ function build_commit_string(
     const temp = commit_state.body.split("\\n"); // literal \n, not new-line.
     const res = temp
       .map((v) => (colorize ? color.reset(v.trim()) : v.trim()))
-      .join("\n");
+      .join("\n")
+      .replaceAll("`", "`");
     commit_string += colorize ? `\n\n${res}` : `\n\n${res}`;
   }
 
@@ -502,7 +503,7 @@ function build_commit_string(
   }
 
   if (escape_quotes) {
-    commit_string = commit_string.replaceAll('"', '\\"');
+    commit_string = commit_string.replaceAll('"', '\\"').replaceAll("`", "\\`");
   }
 
   return commit_string;


### PR DESCRIPTION
Fixed an issue where any text wrapped in `backticks` would be omitted from the message.

Closes: #120