### PR TITLE
fix: add_exclamation_to_title true by default

### DIFF
--- a/src/valibot-state.ts
+++ b/src/valibot-state.ts
@@ -158,7 +158,7 @@ export const Config = v.object({
   ),
   breaking_change: v.optional(
     v.object({
-      add_exclamation_to_title: v.optional(v.boolean(), false),
+      add_exclamation_to_title: v.optional(v.boolean(), true),
     }),
     {},
   ),


### PR DESCRIPTION
According to docs add_exclamation_to_title should be true