### PR TITLE
feat(commit): #127 pass commit state via cli 

### DIFF
--- a/.better-commits.json
+++ b/.better-commits.json
@@ -31,6 +31,10 @@
         "label": "build"
       },
       {
+        "value": "help",
+        "label": "help"
+      },
+      {
         "value": "",
         "label": "none"
       }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: npm test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@clack/prompts": "^1.2.0",
         "configstore": "^5.0.1",
         "picocolors": "^1.0.0",
-        "valibot": "^0.30.0"
+        "valibot": "^1.3.1"
       },
       "bin": {
         "bcommits": "dist/index.js",
@@ -8518,7 +8518,7 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
+      "devOptional": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8626,9 +8626,18 @@
       "dev": true
     },
     "node_modules/valibot": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.30.0.tgz",
-      "integrity": "sha512-5POBdbSkM+3nvJ6ZlyQHsggisfRtyT4tVTo1EIIShs6qCdXJnyWU5TJ68vr8iTg5zpOLjXLRiBqNx+9zwZz/rA=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -16566,7 +16575,7 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
+      "devOptional": true,
       "peer": true
     },
     "uglify-js": {
@@ -16631,9 +16640,10 @@
       "dev": true
     },
     "valibot": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.30.0.tgz",
-      "integrity": "sha512-5POBdbSkM+3nvJ6ZlyQHsggisfRtyT4tVTo1EIIShs6qCdXJnyWU5TJ68vr8iTg5zpOLjXLRiBqNx+9zwZz/rA=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "requires": {}
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.19.1",
       "license": "MIT",
       "dependencies": {
+        "@bomb.sh/args": "^0.3.1",
         "@clack/core": "^1.2.0",
         "@clack/prompts": "^1.2.0",
         "configstore": "^5.0.1",
@@ -99,6 +100,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bomb.sh/args": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@bomb.sh/args/-/args-0.3.1.tgz",
+      "integrity": "sha512-CwxKrfgcorUPP6KfYD59aRdBYWBTsfsxT+GmoLVnKo5Tmyoqbpo0UNcjngRMyU+6tiPbd18RuIYxhgAn44wU/Q=="
     },
     "node_modules/@clack/core": {
       "version": "1.2.0",
@@ -11061,6 +11067,11 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true
+    },
+    "@bomb.sh/args": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@bomb.sh/args/-/args-0.3.1.tgz",
+      "integrity": "sha512-CwxKrfgcorUPP6KfYD59aRdBYWBTsfsxT+GmoLVnKo5Tmyoqbpo0UNcjngRMyU+6tiPbd18RuIYxhgAn44wU/Q=="
     },
     "@clack/core": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@clack/prompts": "^1.2.0",
     "configstore": "^5.0.1",
     "picocolors": "^1.0.0",
-    "valibot": "^0.30.0"
+    "valibot": "^1.3.1"
   },
   "scripts": {
     "start": "tsx ./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "https://github.com/Everduin94/better-commits"
   },
   "dependencies": {
+    "@bomb.sh/args": "^0.3.1",
     "@clack/core": "^1.2.0",
     "@clack/prompts": "^1.2.0",
     "configstore": "^5.0.1",
@@ -33,11 +34,11 @@
     "valibot": "^0.30.0"
   },
   "scripts": {
-    "start": "jiti ./src/index.ts",
-    "branch": "jiti ./src/branch.ts",
-    "init": "jiti ./src/init.ts",
+    "start": "tsx ./src/index.ts",
+    "branch": "tsx ./src/branch.ts",
+    "init": "tsx ./src/init.ts",
     "build": "tsup",
-    "commit": "jiti ./src/index.ts",
+    "commit": "tsx ./src/index.ts",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,9 @@ Some of the values in these prompts will be inferred by your branch name and aut
 For documentation on passing commit values to `better-commits` via the CLI, see [CLI Flags](#cli-flags).
 
 > [!TIP]
-> The --no-interactive flag, allows automated workflows or AI agents like OpenCode and Claude Code, to use better-commits to generate consistent commit messages using less tokens.
+> The `--no-interactive` flag, allows automated workflows or AI agents like OpenCode and Claude Code, to use better-commits to generate consistent commit messages using less tokens.
+>
+> Run `better-commits --help` / `better-branch --help` for more information.
 
 ## ⚙️ Configuration
 
@@ -406,7 +408,7 @@ Optionally configure pre and post checkout commands, for example:
 
 See _branch_pre_commands_ and _branch_post_commands_ in default config. (or _worktree_pre_commands_ and _worktree_post_commands_ for creating worktrees)
 
-## 🌌 Mildly Interesting
+## 💡 Tips & Tricks
 
 ### Building / Versioning
 
@@ -427,7 +429,7 @@ If you're using Github issues to track your work, and select the `closes` footer
 
 `better-commits` can append a commit trailer per commit type. This allows you to [automate change logs](https://docs.gitlab.com/ee/user/project/changelogs.html) with tools like Gitlab.
 
-### Misc
+### Git
 
 `better-commits` uses native `git` commands under the hood. So any hooks, tools, or staging should work as if it was a normal commit.
 
@@ -436,11 +438,13 @@ Setting `confirm_with_editor=true` will allow you to edit/confirm a commit with 
 - For example, to edit with Neovim: `git config --global core.editor "nvim"`
 - For VS Code, `git config --global core.editor "code -n --wait"`
 
-You can add this badge to your repository to display that you're using a better-commits repository config
+You can pass arguments to `git` through `better-commits` like so:
 
-| Markdown                                                                                                                                                                                                          | Result                                                                                                                                                                                                          |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `[![better commits is enabled](https://img.shields.io/badge/better--commits-enabled?style=for-the-badge&logo=git&color=a6e3a1&logoColor=D9E0EE&labelColor=302D41)](https://github.com/Everduin94/better-commits)` | [![better commits is enabled](https://img.shields.io/badge/better--commits-enabled?style=for-the-badge&logo=git&color=a6e3a1&logoColor=D9E0EE&labelColor=302D41)](https://github.com/Everduin94/better-commits) |
+```sh
+better-commits --git-dir="$HOME/.config" --work-tree="$HOME"
+```
+
+A practical example of this would be managing dotfiles, as described in this [Atlassian Article](https://www.atlassian.com/git/tutorials/dotfiles)
 
 ### CLI Flags
 
@@ -449,20 +453,15 @@ Use CLI flags to pass commit values directly instead of answering prompts.
 - Use `--no-interactive` to skip prompts, confirmation, and editor flows. This is the recommended mode for OpenCode, Claude Code, and other coding agents.
 - Use `--dry-run` to validate the generated `git commit` command without creating a commit.
 - Supported commit field flags: `--type`, `--scope`, `--title`, `--body`, `--ticket`, `--closes`, `--deprecates`, `--breaking-title`, `--breaking-body`, `--deprecates-title`, `--deprecates-body`, `--custom-footer`, `--trailer`.
+- Supported branch field flags: `--user`, `--type`, `--description`, `--ticket`, `--branch-version`, `--checkout`.
+
+**Examples**
 
 ```sh
 better-commits --no-interactive --dry-run --type feat --scope cli --title "add parser"
+
+better-branch --no-interactive --type feat --ticket TAC-123 --description "add parser" --checkout worktree
 ```
-
-### Git Arguments
-
-You can pass arguments to `git` through `better-commits` like so:
-
-```sh
-better-commits --git-dir="$HOME/.config" --work-tree="$HOME"
-```
-
-A practical example of this would be managing dotfiles, as described in this [Atlassian Article](https://www.atlassian.com/git/tutorials/dotfiles)
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -49,10 +49,14 @@ better-commits # Create a new commit
 better-branch # Create a new branch
 ```
 
-`better-commits` will prompt a series of questions. These prompts will build a commit message, which you can preview, before confirming the commit.
+`better-commits` will prompt a series of questions. These prompts will build a commit message, which you can preview, before confirming the commit. - To better understand these prompts and their intention, read [Conventional Commits Summary](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
+
 Some of the values in these prompts will be inferred by your branch name and auto populated. You can adjust this in your `.better-commits.json` configuration file.
 
-To better understand these prompts and their intention, read [Conventional Commits Summary](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
+For documentation on passing commit values to `better-commits` via the CLI, see [CLI Flags](#cli-flags).
+
+> [!TIP]
+> The --no-interactive flag, allows automated workflows or AI agents like OpenCode and Claude Code, to use better-commits to generate consistent commit messages using less tokens.
 
 ## ⚙️ Configuration
 
@@ -437,6 +441,18 @@ You can add this badge to your repository to display that you're using a better-
 | Markdown                                                                                                                                                                                                          | Result                                                                                                                                                                                                          |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `[![better commits is enabled](https://img.shields.io/badge/better--commits-enabled?style=for-the-badge&logo=git&color=a6e3a1&logoColor=D9E0EE&labelColor=302D41)](https://github.com/Everduin94/better-commits)` | [![better commits is enabled](https://img.shields.io/badge/better--commits-enabled?style=for-the-badge&logo=git&color=a6e3a1&logoColor=D9E0EE&labelColor=302D41)](https://github.com/Everduin94/better-commits) |
+
+### CLI Flags
+
+Use CLI flags to pass commit values directly instead of answering prompts.
+
+- Use `--no-interactive` to skip prompts, confirmation, and editor flows. This is the recommended mode for OpenCode, Claude Code, and other coding agents.
+- Use `--dry-run` to validate the generated `git commit` command without creating a commit.
+- Supported commit field flags: `--type`, `--scope`, `--title`, `--body`, `--ticket`, `--closes`, `--deprecates`, `--breaking-title`, `--breaking-body`, `--deprecates-title`, `--deprecates-body`, `--custom-footer`, `--trailer`.
+
+```sh
+better-commits --no-interactive --dry-run --type feat --scope cli --title "add parser"
+```
 
 ### Git Arguments
 

--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { parse_runtime_flags } from "./args";
+
+describe("parse_runtime_flags", () => {
+  it("uses interactive mode by default", () => {
+    const parsed = parse_runtime_flags([]);
+
+    expect(parsed.no_interactive).toBe(false);
+    expect(parsed.dry_run).toBe(false);
+    expect(parsed.git_args).toBe("");
+    expect(parsed.commit_state).toEqual({});
+  });
+
+  it("parses --no-interactive and --dry-run", () => {
+    const parsed = parse_runtime_flags(["--no-interactive", "--dry-run"]);
+
+    expect(parsed.no_interactive).toBe(true);
+    expect(parsed.dry_run).toBe(true);
+  });
+
+  it("maps commit flags into commit_state keys", () => {
+    const parsed = parse_runtime_flags([
+      "--type",
+      "feat",
+      "--title",
+      "ship feature",
+      "--breaking-title",
+      "api changed",
+      "--custom-footer",
+      "Reviewed-by: Jane",
+    ]);
+
+    expect(parsed.commit_state).toEqual({
+      type: "feat",
+      title: "ship feature",
+      breaking_title: "api changed",
+      custom_footer: "Reviewed-by: Jane",
+    });
+  });
+
+  it("builds git args from --git-dir and --work-tree", () => {
+    const parsed = parse_runtime_flags([
+      "--git-dir",
+      "/tmp/repo/.git",
+      "--work-tree",
+      "/tmp/repo",
+    ]);
+
+    expect(parsed.git_args).toBe(
+      "--git-dir=/tmp/repo/.git --work-tree=/tmp/repo",
+    );
+  });
+
+  it("builds git args when only one git location flag is provided", () => {
+    const with_git_dir = parse_runtime_flags(["--git-dir", "/tmp/repo/.git"]);
+    const with_work_tree = parse_runtime_flags(["--work-tree", "/tmp/repo"]);
+
+    expect(with_git_dir.git_args).toBe("--git-dir=/tmp/repo/.git");
+    expect(with_work_tree.git_args).toBe("--work-tree=/tmp/repo");
+  });
+
+  it("maps dashed commit flags to snake_case commit_state keys", () => {
+    const parsed = parse_runtime_flags([
+      "--breaking-body",
+      "major impact",
+      "--deprecates-title",
+      "legacy endpoint",
+      "--deprecates-body",
+      "use v2 endpoint",
+      "--custom-footer",
+      "Reviewed-by: Alex",
+      "--breaking-title",
+      "v1 removed",
+    ]);
+
+    expect(parsed.commit_state).toEqual({
+      breaking_body: "major impact",
+      deprecates_title: "legacy endpoint",
+      deprecates_body: "use v2 endpoint",
+      custom_footer: "Reviewed-by: Alex",
+      breaking_title: "v1 removed",
+    });
+  });
+
+  it("honors interactive flag semantics", () => {
+    const default_flags = parse_runtime_flags([]);
+    const explicit_interactive = parse_runtime_flags(["--interactive"]);
+    const no_interactive = parse_runtime_flags(["--no-interactive"]);
+
+    expect(default_flags.no_interactive).toBe(false);
+    expect(explicit_interactive.no_interactive).toBe(false);
+    expect(no_interactive.no_interactive).toBe(true);
+  });
+});

--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -18,6 +18,14 @@ describe("parse_runtime_flags", () => {
     expect(parsed.dry_run).toBe(true);
   });
 
+  it("parses --version and -v", () => {
+    const long_flag = parse_runtime_flags(["--version"]);
+    const short_flag = parse_runtime_flags(["-v"]);
+
+    expect(long_flag.version).toBe(true);
+    expect(short_flag.version).toBe(true);
+  });
+
   it("maps commit flags into commit_state keys", () => {
     const parsed = parse_runtime_flags([
       "--type",

--- a/src/args.ts
+++ b/src/args.ts
@@ -5,13 +5,14 @@ import { CommitState } from "./valibot-state";
 type CommitStateRuntime = Output<typeof CommitState>;
 
 type ParsedRuntimeFlags = {
+  help: boolean;
   git_args: string;
   no_interactive: boolean;
   dry_run: boolean;
   commit_state: Partial<CommitStateRuntime>;
 };
 
-const COMMIT_OPTIONS = [
+export const COMMIT_OPTIONS = [
   "type",
   "scope",
   "title",
@@ -27,9 +28,9 @@ const COMMIT_OPTIONS = [
   "custom-footer",
 ] as const;
 
-const GIT_OPTIONS = ["git-dir", "work-tree"] as const;
+export const GIT_OPTIONS = ["git-dir", "work-tree"] as const;
 
-const BOOLEAN_FLAGS = ["interactive", "dry-run"] as const;
+export const BOOLEAN_FLAGS = ["interactive", "dry-run", "help"] as const;
 
 class Flags {
   #runtime: ParsedRuntimeFlags;
@@ -48,6 +49,10 @@ class Flags {
 
   get dry_run(): boolean {
     return this.#runtime.dry_run;
+  }
+
+  get help(): boolean {
+    return this.#runtime.help;
   }
 
   get commit_state(): Partial<CommitStateRuntime> {
@@ -73,6 +78,7 @@ export function parse_runtime_flags(argv: string[]): ParsedRuntimeFlags {
   });
 
   return {
+    help: parsed["help"] === true,
     git_args: get_git_args(parsed["git-dir"], parsed["work-tree"]),
     no_interactive: parsed.interactive === false,
     dry_run: parsed["dry-run"] === true,

--- a/src/args.ts
+++ b/src/args.ts
@@ -6,6 +6,7 @@ type CommitStateRuntime = InferOutput<typeof CommitState>;
 
 type ParsedRuntimeFlags = {
   help: boolean;
+  version: boolean;
   git_args: string;
   no_interactive: boolean;
   dry_run: boolean;
@@ -30,7 +31,12 @@ export const COMMIT_OPTIONS = [
 
 export const GIT_OPTIONS = ["git-dir", "work-tree"] as const;
 
-export const BOOLEAN_FLAGS = ["interactive", "dry-run", "help"] as const;
+export const BOOLEAN_FLAGS = [
+  "interactive",
+  "dry-run",
+  "help",
+  "version",
+] as const;
 
 class Flags {
   #runtime: ParsedRuntimeFlags;
@@ -55,6 +61,10 @@ class Flags {
     return this.#runtime.help;
   }
 
+  get version(): boolean {
+    return this.#runtime.version;
+  }
+
   get commit_state(): Partial<CommitStateRuntime> {
     return this.#runtime.commit_state;
   }
@@ -64,6 +74,7 @@ export const flags = new Flags(parse_runtime_flags(process.argv.slice(2)));
 
 export function parse_runtime_flags(argv: string[]): ParsedRuntimeFlags {
   const parsed = parse(argv, {
+    alias: { h: "help", v: "version" },
     boolean: BOOLEAN_FLAGS,
     string: [...COMMIT_OPTIONS, ...GIT_OPTIONS],
   });
@@ -79,6 +90,7 @@ export function parse_runtime_flags(argv: string[]): ParsedRuntimeFlags {
 
   return {
     help: parsed["help"] === true,
+    version: parsed["version"] === true,
     git_args: get_git_args(parsed["git-dir"], parsed["work-tree"]),
     no_interactive: parsed.interactive === false,
     dry_run: parsed["dry-run"] === true,

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,12 +1,88 @@
+import { parse } from "@bomb.sh/args";
+import { Output } from "valibot";
+import { CommitState } from "./valibot-state";
+
+type CommitStateRuntime = Output<typeof CommitState>;
+
+type ParsedRuntimeFlags = {
+  git_args: string;
+  no_interactive: boolean;
+  dry_run: boolean;
+  commit_state: Partial<CommitStateRuntime>;
+};
+
+const COMMIT_OPTIONS = [
+  "type",
+  "scope",
+  "title",
+  "body",
+  "closes",
+  "ticket",
+  "trailer",
+  "deprecates",
+  "breaking-title",
+  "breaking-body",
+  "deprecates-title",
+  "deprecates-body",
+  "custom-footer",
+] as const;
+
+const GIT_OPTIONS = ["git-dir", "work-tree"] as const;
+
+const BOOLEAN_FLAGS = ["interactive", "dry-run"] as const;
+
 class Flags {
-  #git_args: string = "";
-  constructor() {}
-  get git_args() {
-    return this.#git_args;
+  #runtime: ParsedRuntimeFlags;
+
+  constructor(runtime: ParsedRuntimeFlags) {
+    this.#runtime = runtime;
   }
-  set git_args(value: string) {
-    this.#git_args = value;
+
+  get git_args(): string {
+    return this.#runtime.git_args;
+  }
+
+  get interactive(): boolean {
+    return !this.#runtime.no_interactive;
+  }
+
+  get dry_run(): boolean {
+    return this.#runtime.dry_run;
+  }
+
+  get commit_state(): Partial<CommitStateRuntime> {
+    return this.#runtime.commit_state;
   }
 }
 
-export const flags = new Flags();
+export const flags = new Flags(parse_runtime_flags(process.argv.slice(2)));
+
+export function parse_runtime_flags(argv: string[]): ParsedRuntimeFlags {
+  const parsed = parse(argv, {
+    boolean: BOOLEAN_FLAGS,
+    string: [...COMMIT_OPTIONS, ...GIT_OPTIONS],
+  });
+
+  const commit_state: Partial<CommitStateRuntime> = {};
+  COMMIT_OPTIONS.forEach((value) => {
+    const cli_value = parsed[value];
+    if (cli_value) {
+      const str = value.replace("-", "_") as keyof CommitStateRuntime;
+      commit_state[str] = cli_value;
+    }
+  });
+
+  return {
+    git_args: get_git_args(parsed["git-dir"], parsed["work-tree"]),
+    no_interactive: parsed.interactive === false,
+    dry_run: parsed["dry-run"] === true,
+    commit_state,
+  };
+}
+
+function get_git_args(
+  git_dir: string | undefined,
+  work_tree: string | undefined,
+): string {
+  return `${git_dir ? `--git-dir=${git_dir}` : ""} ${work_tree ? `--work-tree=${work_tree}` : ""}`.trim();
+}

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,8 +1,8 @@
 import { parse } from "@bomb.sh/args";
-import { Output } from "valibot";
+import { InferOutput } from "valibot";
 import { CommitState } from "./valibot-state";
 
-type CommitStateRuntime = Output<typeof CommitState>;
+type CommitStateRuntime = InferOutput<typeof CommitState>;
 
 type ParsedRuntimeFlags = {
   help: boolean;

--- a/src/branch-args.test.ts
+++ b/src/branch-args.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { parse_branch_runtime_flags } from "./branch-args";
+
+describe("parse_branch_runtime_flags", () => {
+  it("maps branch flags into branch_state keys", () => {
+    const parsed = parse_branch_runtime_flags([
+      "--user",
+      "erik",
+      "--type",
+      "feat",
+      "--ticket",
+      "ABC-123",
+      "--description",
+      "add-parser",
+      "--version",
+      "1.2.0",
+    ]);
+
+    expect(parsed.branch_state).toEqual({
+      user: "erik",
+      type: "feat",
+      ticket: "ABC-123",
+      description: "add-parser",
+      version: "1.2.0",
+    });
+  });
+
+  it("maps --checkout into checkout", () => {
+    const parsed = parse_branch_runtime_flags(["--checkout", "worktree"]);
+
+    expect(parsed.branch_state).toEqual({
+      checkout: "worktree",
+    });
+  });
+
+  it("honors interactive flag semantics", () => {
+    const default_flags = parse_branch_runtime_flags([]);
+    const explicit_interactive = parse_branch_runtime_flags(["--interactive"]);
+    const no_interactive = parse_branch_runtime_flags(["--no-interactive"]);
+
+    expect(default_flags.no_interactive).toBe(false);
+    expect(explicit_interactive.no_interactive).toBe(false);
+    expect(no_interactive.no_interactive).toBe(true);
+  });
+});

--- a/src/branch-args.test.ts
+++ b/src/branch-args.test.ts
@@ -12,7 +12,7 @@ describe("parse_branch_runtime_flags", () => {
       "ABC-123",
       "--description",
       "add-parser",
-      "--version",
+      "--branch-version",
       "1.2.0",
     ]);
 
@@ -33,6 +33,20 @@ describe("parse_branch_runtime_flags", () => {
     });
   });
 
+  it("does not set checkout when --checkout is omitted", () => {
+    const parsed = parse_branch_runtime_flags([
+      "--type",
+      "feat",
+      "--description",
+      "add-parser",
+    ]);
+
+    expect(parsed.branch_state).toEqual({
+      type: "feat",
+      description: "add-parser",
+    });
+  });
+
   it("honors interactive flag semantics", () => {
     const default_flags = parse_branch_runtime_flags([]);
     const explicit_interactive = parse_branch_runtime_flags(["--interactive"]);
@@ -41,5 +55,18 @@ describe("parse_branch_runtime_flags", () => {
     expect(default_flags.no_interactive).toBe(false);
     expect(explicit_interactive.no_interactive).toBe(false);
     expect(no_interactive.no_interactive).toBe(true);
+  });
+
+  it("parses git-dir and work-tree into git_args", () => {
+    const parsed = parse_branch_runtime_flags([
+      "--git-dir",
+      "/tmp/repo/.git",
+      "--work-tree",
+      "/tmp/repo",
+    ]);
+
+    expect(parsed.git_args).toBe(
+      "--git-dir=/tmp/repo/.git --work-tree=/tmp/repo",
+    );
   });
 });

--- a/src/branch-args.ts
+++ b/src/branch-args.ts
@@ -1,0 +1,77 @@
+import { parse } from "@bomb.sh/args";
+import { InferOutput } from "valibot";
+import { BranchState } from "./valibot-state";
+
+type BranchStateRuntime = InferOutput<typeof BranchState>;
+
+type ParsedRuntimeFlags = {
+  help: boolean;
+  no_interactive: boolean;
+  dry_run: boolean;
+  branch_state: Partial<BranchStateRuntime>;
+};
+
+const BRANCH_OPTIONS = [
+  "user",
+  "type",
+  "description",
+  "ticket",
+  "version",
+  "checkout",
+] as const;
+
+export const BOOLEAN_FLAGS = ["interactive", "dry-run", "help"] as const;
+
+class BranchFlags {
+  #runtime: ParsedRuntimeFlags;
+
+  constructor(runtime: ParsedRuntimeFlags) {
+    this.#runtime = runtime;
+  }
+
+  get interactive(): boolean {
+    return !this.#runtime.no_interactive;
+  }
+
+  get dry_run(): boolean {
+    return this.#runtime.dry_run;
+  }
+
+  get help(): boolean {
+    return this.#runtime.help;
+  }
+
+  get branch_state(): Partial<BranchStateRuntime> {
+    return this.#runtime.branch_state;
+  }
+}
+
+export const branch_flags = new BranchFlags(
+  parse_branch_runtime_flags(process.argv.slice(2)),
+);
+
+export function parse_branch_runtime_flags(argv: string[]): ParsedRuntimeFlags {
+  const parsed = parse(argv, {
+    boolean: BOOLEAN_FLAGS,
+    string: BRANCH_OPTIONS,
+  });
+
+  const branch_state: Partial<BranchStateRuntime> = {};
+  BRANCH_OPTIONS.forEach((value) => {
+    const cli_value = parsed[value];
+    if (cli_value) {
+      const str = value.replace("-", "_") as keyof BranchStateRuntime;
+      if (str === "checkout_type")
+        branch_state[str] =
+          (cli_value as "worktree" | "branch" | undefined) ?? "branch";
+      else branch_state[str] = cli_value;
+    }
+  });
+
+  return {
+    help: parsed["help"] === true,
+    no_interactive: parsed.interactive === false,
+    dry_run: parsed["dry-run"] === true,
+    branch_state: branch_state,
+  };
+}

--- a/src/branch-args.ts
+++ b/src/branch-args.ts
@@ -61,7 +61,7 @@ export function parse_branch_runtime_flags(argv: string[]): ParsedRuntimeFlags {
     const cli_value = parsed[value];
     if (cli_value) {
       const str = value.replace("-", "_") as keyof BranchStateRuntime;
-      if (str === "checkout_type")
+      if (str === "checkout")
         branch_state[str] =
           (cli_value as "worktree" | "branch" | undefined) ?? "branch";
       else branch_state[str] = cli_value;

--- a/src/branch-args.ts
+++ b/src/branch-args.ts
@@ -6,6 +6,8 @@ type BranchStateRuntime = InferOutput<typeof BranchState>;
 
 type ParsedRuntimeFlags = {
   help: boolean;
+  version: boolean;
+  git_args: string;
   no_interactive: boolean;
   dry_run: boolean;
   branch_state: Partial<BranchStateRuntime>;
@@ -16,11 +18,18 @@ const BRANCH_OPTIONS = [
   "type",
   "description",
   "ticket",
-  "version",
+  "branch-version",
   "checkout",
 ] as const;
 
-export const BOOLEAN_FLAGS = ["interactive", "dry-run", "help"] as const;
+export const GIT_OPTIONS = ["git-dir", "work-tree"] as const;
+
+export const BOOLEAN_FLAGS = [
+  "interactive",
+  "dry-run",
+  "help",
+  "version",
+] as const;
 
 class BranchFlags {
   #runtime: ParsedRuntimeFlags;
@@ -41,6 +50,14 @@ class BranchFlags {
     return this.#runtime.help;
   }
 
+  get version(): boolean {
+    return this.#runtime.version;
+  }
+
+  get git_args(): string {
+    return this.#runtime.git_args;
+  }
+
   get branch_state(): Partial<BranchStateRuntime> {
     return this.#runtime.branch_state;
   }
@@ -52,15 +69,18 @@ export const branch_flags = new BranchFlags(
 
 export function parse_branch_runtime_flags(argv: string[]): ParsedRuntimeFlags {
   const parsed = parse(argv, {
+    alias: { h: "help", v: "version" },
     boolean: BOOLEAN_FLAGS,
-    string: BRANCH_OPTIONS,
+    string: [...BRANCH_OPTIONS, ...GIT_OPTIONS],
   });
 
   const branch_state: Partial<BranchStateRuntime> = {};
   BRANCH_OPTIONS.forEach((value) => {
     const cli_value = parsed[value];
     if (cli_value) {
-      const str = value.replace("-", "_") as keyof BranchStateRuntime;
+      const str = (value === "branch-version"
+        ? "version"
+        : value.replace("-", "_")) as keyof BranchStateRuntime;
       if (str === "checkout")
         branch_state[str] =
           (cli_value as "worktree" | "branch" | undefined) ?? "branch";
@@ -70,8 +90,17 @@ export function parse_branch_runtime_flags(argv: string[]): ParsedRuntimeFlags {
 
   return {
     help: parsed["help"] === true,
-    no_interactive: parsed.interactive === false,
+    version: parsed["version"] === true,
+    git_args: get_git_args(parsed["git-dir"], parsed["work-tree"]),
+    no_interactive: parsed["interactive"] === false,
     dry_run: parsed["dry-run"] === true,
     branch_state: branch_state,
   };
+}
+
+function get_git_args(
+  git_dir: string | undefined,
+  work_tree: string | undefined,
+): string {
+  return `${git_dir ? `--git-dir=${git_dir}` : ""} ${work_tree ? `--work-tree=${work_tree}` : ""}`.trim();
 }

--- a/src/branch-help.ts
+++ b/src/branch-help.ts
@@ -1,37 +1,24 @@
 import { execSync } from "child_process";
 import { InferOutput } from "valibot";
-import { flags } from "./args";
+import { branch_flags } from "./branch-args";
 import { get_package_version } from "./utils";
 import { infer_ticket_from_git, infer_type_from_git } from "./utils/infer";
 import { Config } from "./valibot-state";
 import color from "picocolors";
 
-const ADDITIONAL_COMMAND_DEFINITIONS: Record<string, string> = {
-  "better-branch": "Create a branch or worktree from a guided prompt flow.",
-  "better-commits-init":
-    "Create a .better-commits.json config in this repository.",
-};
-
 const CLI_FLAG_DEFINITIONS: Record<string, string> = {
   "--interactive": "Run in interactive prompt mode (default behavior).",
-  "--dry-run": "Print the commit command without creating a commit.",
+  "--dry-run": "Print branch commands without creating a branch or worktree.",
   "--help": "Show help information and exit.",
 };
 
-const COMMIT_FLAG_DEFINITIONS: Record<string, string> = {
-  "--type": "Set commit type (for example feat, fix, docs).",
-  "--scope": "Set commit scope.",
-  "--title": "Set commit title/description.",
-  "--body": "Set commit body text.",
-  "--closes": "Set issue/ticket id for a closes footer.",
-  "--ticket": "Set ticket value used in the title.",
-  "--trailer": "Set trailer footer value.",
-  "--deprecates": "Set issue/ticket id for a deprecates footer.",
-  "--breaking-title": "Set breaking-change title footer.",
-  "--breaking-body": "Set breaking-change body footer.",
-  "--deprecates-title": "Set deprecates footer title text.",
-  "--deprecates-body": "Set deprecates footer body text.",
-  "--custom-footer": "Set a custom footer line.",
+const BRANCH_FLAG_DEFINITIONS: Record<string, string> = {
+  "--user": "Set branch username segment.",
+  "--type": "Set branch type (for example feat, fix, docs).",
+  "--description": "Set branch description segment.",
+  "--ticket": "Set branch ticket/issue segment.",
+  "--branch-version": "Set branch version segment.",
+  "--checkout": "Choose branch or worktree checkout mode.",
 };
 
 const GIT_FLAG_DEFINITIONS: Record<string, string> = {
@@ -64,7 +51,9 @@ export function print_help_text(
   let branch = "(none)";
   try {
     branch =
-      execSync(`git ${flags.git_args} branch --show-current`, { stdio: "pipe" })
+      execSync(`git ${branch_flags.git_args} branch --show-current`, {
+        stdio: "pipe",
+      })
         .toString()
         .trim() || "(none)";
   } catch {
@@ -72,7 +61,7 @@ export function print_help_text(
   }
 
   const inferred_type =
-    infer_type_from_git(config.commit_type.options, flags.git_args) ||
+    infer_type_from_git(config.commit_type.options, branch_flags.git_args) ||
     "Unknown";
   const inferred_ticket = config.check_ticket.infer_ticket
     ? infer_ticket_from_git(
@@ -80,7 +69,7 @@ export function print_help_text(
           append_hashtag: config.check_ticket.append_hashtag,
           prepend_hashtag: config.check_ticket.prepend_hashtag,
         },
-        flags.git_args,
+        branch_flags.git_args,
       ) || "Unknown"
     : "Infer Disabled";
 
@@ -94,13 +83,10 @@ export function print_help_text(
     .trim();
   const cli_flags = to_definition_lines(CLI_FLAG_DEFINITIONS);
   const git_flags = to_definition_lines(GIT_FLAG_DEFINITIONS);
-  const commit_flags = to_definition_lines(COMMIT_FLAG_DEFINITIONS);
-  const additional_commands = to_definition_lines(
-    ADDITIONAL_COMMAND_DEFINITIONS,
-  );
+  const branch_flags_help = to_definition_lines(BRANCH_FLAG_DEFINITIONS);
 
   console.log(`
-${color.green(" better-commits")} ${color.gray("v" + version)}
+${color.green(" better-branch")} ${color.gray("v" + version)}
 
 ${color.gray("BRANCH")} 
  ${branch}
@@ -118,14 +104,11 @@ ${color.gray("Scopes")}
 ${color.gray("CLI FLAGS")} 
 ${cli_flags}
 
-${color.gray("Commit Flags")} 
-${commit_flags}
+${color.gray("Branch Flags")} 
+${branch_flags_help}
 
 ${color.gray("Git Flags (Advanced)")} 
 ${git_flags}
-
-${color.gray("ADDITIONAL COMMANDS")} 
-${additional_commands}
 
 `);
 }

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -1,218 +1,50 @@
 #! /usr/bin/env node
 
-import * as p from "@clack/prompts";
-import { execSync } from "child_process";
 import Configstore from "configstore";
-import color from "picocolors";
 import { chdir } from "process";
 import { InferOutput, parse } from "valibot";
-import { V_BRANCH_ACTIONS } from "./valibot-consts";
 import { BranchState, CommitState, Config } from "./valibot-state";
-import { BRANCH_ACTION_OPTIONS, load_setup, get_git_root } from "./utils";
-import { optional_message } from "./utils/messages";
+import { load_setup, get_git_root, NOOP_PROMPT_CACHE } from "./utils";
 import { flags } from "./args";
-import { build_branch, build_worktree_path } from "./utils/build-branch";
+import { BranchRunnable } from "./prompts/branch-runnable";
+import { BranchCheckoutPrompt } from "./prompts/branch-checkout.prompt";
+import { BranchUserPrompt } from "./prompts/branch-user.prompt";
+import { BranchTypePrompt } from "./prompts/branch-type.prompt";
+import { BranchTicketPrompt } from "./prompts/branch-ticket.prompt";
+import { BranchVersionPrompt } from "./prompts/branch-version.prompt";
+import { BranchDescriptionPrompt } from "./prompts/branch-description.prompt";
+import { BranchConfirmPrompt } from "./prompts/branch-confirm.prompt";
 
 main(load_setup(" better-branch "));
 
+type PromptCtor = new (
+  config: InferOutput<typeof Config>,
+  commit_state: InferOutput<typeof BranchState>,
+  prompt_cache: Configstore,
+) => BranchRunnable;
+
+const promptCtors: PromptCtor[] = [
+  BranchCheckoutPrompt,
+  BranchUserPrompt,
+  BranchTypePrompt,
+  BranchTicketPrompt,
+  BranchVersionPrompt,
+  BranchDescriptionPrompt,
+  BranchConfirmPrompt,
+];
+
 async function main(config: InferOutput<typeof Config>) {
-  const branch_state = parse(BranchState, {});
   chdir(get_git_root());
 
-  let checkout_type: InferOutput<typeof V_BRANCH_ACTIONS> = "branch";
-  if (config.worktrees.enable) {
-    const branch_or_worktree = await p.select({
-      message: `Checkout a branch or create a worktree?`,
-      initialValue: config.branch_action_default,
-      options: BRANCH_ACTION_OPTIONS,
-    });
-
-    if (p.isCancel(branch_or_worktree)) process.exit();
-    checkout_type = branch_or_worktree;
-  }
-
-  if (config.branch_user.enable) {
-    const cache_user_name = get_user_from_cache();
-    const user_name_required = config.branch_user.required;
-    const user_name = await p.text({
-      message: user_name_required
-        ? "Type your git username"
-        : optional_message("Type your git username"),
-      placeholder: "",
-      initialValue: cache_user_name,
-      validate: (val) => {
-        if (user_name_required && !val) return "Please enter a username";
-      },
-    });
-    if (p.isCancel(user_name)) process.exit(0);
-    branch_state.user = user_name?.replace(/\s+/g, "-")?.toLowerCase() ?? "";
-    set_user_cache(branch_state.user);
-  }
-
-  if (config.branch_type.enable) {
-    let initial_value = config.commit_type.initial_value;
-    const commit_type = await p.select({
-      message: `Select a branch type`,
-      initialValue: initial_value,
-      options: config.commit_type.options,
-    });
-    if (p.isCancel(commit_type)) process.exit(0);
-    branch_state.type = commit_type;
-  }
-
-  if (config.branch_ticket.enable) {
-    const ticked_required = config.branch_ticket.required;
-    const ticket = await p.text({
-      message: ticked_required
-        ? "Type ticket / issue number"
-        : optional_message("Type ticket / issue number"),
-      placeholder: "",
-      validate: (val) => {
-        if (ticked_required && !val) return "Please enter a ticket / issue";
-      },
-    });
-    if (p.isCancel(ticket)) process.exit(0);
-    branch_state.ticket = ticket;
-  }
-
-  if (config.branch_version.enable) {
-    const version_required = config.branch_version.required;
-    const version = await p.text({
-      message: version_required
-        ? "Type version number"
-        : optional_message("Type version number"),
-      placeholder: "",
-      validate: (val) => {
-        if (version_required && !val) return "Please enter a version";
-      },
-    });
-    if (p.isCancel(version)) process.exit(0);
-    branch_state.version = version;
-  }
-
-  const description_max_length = config.branch_description.max_length;
-  const description = await p.text({
-    message: "Type a short description",
-    placeholder: "",
-    validate: (value) => {
-      if (!value) return "Please enter a description";
-      if (value.length > description_max_length)
-        return `Exceeded max length. Description max [${description_max_length}]`;
-    },
-  });
-  if (p.isCancel(description)) process.exit(0);
-  branch_state.description =
-    description?.replace(/\s+/g, "-")?.toLowerCase() ?? "";
-
-  const pre_commands =
-    checkout_type === "worktree"
-      ? config.worktree_pre_commands
-      : config.branch_pre_commands;
-  pre_commands.forEach((command) => {
-    try {
-      execSync(command, { stdio: "inherit" });
-    } catch (err) {
-      p.log.error("Something went wrong when executing pre-commands: " + err);
-      process.exit(0);
-    }
-  });
-
-  const branch_name = build_branch(branch_state, config);
-  const branch_flag = verify_branch_name(branch_name);
-  if (checkout_type === "branch") {
-    try {
-      execSync(`git ${flags.git_args} checkout ${branch_flag} ${branch_name}`, {
-        stdio: "inherit",
-      });
-      p.log.info(
-        `Switched to a new branch '${color.bgGreen(
-          " " + color.black(branch_name) + " ",
-        )}'`,
-      );
-    } catch (err) {
-      process.exit(0);
-    }
-  } else {
-    try {
-      const worktree_name = build_worktree_path(
-        branch_state,
-        config,
-        get_git_root(),
-      );
-      execSync(
-        `git worktree add ${worktree_name} ${branch_flag} ${branch_name}`,
-        {
-          stdio: "inherit",
-        },
-      );
-      p.log.info(
-        `Created a new worktree ${color.bgGreen(
-          +" " + color.black(worktree_name) + " ",
-        )}, checked out branch ${color.bgGreen(
-          " " + color.black(branch_name) + " ",
-        )}`,
-      );
-      p.log.info(
-        color.bgMagenta(color.black(` cd ${worktree_name} `)) +
-          " to navigate to your new worktree",
-      );
-      chdir(worktree_name);
-    } catch (err) {
-      process.exit(0);
-    }
-  }
-
-  const post_commands =
-    checkout_type === "worktree"
-      ? config.worktree_post_commands
-      : config.branch_post_commands;
-  post_commands.forEach((command) => {
-    try {
-      execSync(command, { stdio: "inherit" });
-    } catch (err) {
-      p.log.error("Something went wrong when executing post-commands: " + err);
-      process.exit(0);
-    }
-  });
-}
-
-function get_user_from_cache(): string {
-  try {
-    const config_store = new Configstore("better-commits");
-    return config_store.get("username") ?? "";
-  } catch (err) {
-    p.log.warn(
-      'There was an issue accessing username from cache. Check that the folder "~/.config" exists',
-    );
-  }
-
-  return "";
-}
-
-function verify_branch_name(branch_name: string): string {
-  // TODO: There has to be a better way 🤦
-  let branch_flag = "";
-  try {
-    execSync(`git show-ref ${branch_name}`, { encoding: "utf-8" });
-    p.log.warning(
-      color.yellow(
-        `${branch_name} already exists! Checking out existing branch.`,
-      ),
-    );
-  } catch (err) {
-    // Branch does not exist
-    branch_flag = "-b";
-  }
-
-  return branch_flag;
-}
-
-function set_user_cache(val: string): void {
-  try {
-    const config_store = new Configstore("better-commits");
-    config_store.set("username", val);
-  } catch (err) {
-    // fail silently, user has likely already seen guidance via get exceptions at this point
+  const branch_state = parse(BranchState, {});
+  const prompt_cache = config.cache_last_value
+    ? new Configstore("better-commits")
+    : NOOP_PROMPT_CACHE;
+  const prompts_to_run = flags.interactive
+    ? promptCtors
+    : [BranchConfirmPrompt];
+  for (const Prompt of prompts_to_run) {
+    await new Prompt(config, branch_state, prompt_cache).run();
   }
 }
 

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -6,15 +6,12 @@ import Configstore from "configstore";
 import color from "picocolors";
 import { chdir } from "process";
 import { Output, parse } from "valibot";
-import {
-  V_BRANCH_ACTIONS,
-  V_BRANCH_CONFIG_FIELDS,
-  V_BRANCH_FIELDS,
-} from "./valibot-consts";
+import { V_BRANCH_ACTIONS } from "./valibot-consts";
 import { BranchState, CommitState, Config } from "./valibot-state";
 import { BRANCH_ACTION_OPTIONS, load_setup, get_git_root } from "./utils";
 import { optional_message } from "./utils/messages";
 import { flags } from "./args";
+import { build_branch, build_worktree_path } from "./utils/build-branch";
 
 main(load_setup(" better-branch "));
 
@@ -137,7 +134,11 @@ async function main(config: Output<typeof Config>) {
     }
   } else {
     try {
-      const worktree_name = build_worktree_path(branch_state, config);
+      const worktree_name = build_worktree_path(
+        branch_state,
+        config,
+        get_git_root(),
+      );
       execSync(
         `git worktree add ${worktree_name} ${branch_flag} ${branch_name}`,
         {
@@ -173,47 +174,6 @@ async function main(config: Output<typeof Config>) {
       process.exit(0);
     }
   });
-}
-
-function build_branch(
-  branch: Output<typeof BranchState>,
-  config: Output<typeof Config>,
-) {
-  let res = "";
-  config.branch_order.forEach((b: Output<typeof V_BRANCH_FIELDS>) => {
-    const config_key: Output<typeof V_BRANCH_CONFIG_FIELDS> = `branch_${b}`;
-    if (branch[b]) res += branch[b] + config[config_key].separator;
-  });
-  if (res.endsWith("-") || res.endsWith("/") || res.endsWith("_")) {
-    return res.slice(0, -1).trim();
-  }
-  return res.trim();
-}
-
-function build_worktree_path(
-  branch_state: Output<typeof BranchState>,
-  config: Output<typeof Config>,
-): string {
-  const gitRoot = get_git_root();
-  const repo_name = gitRoot.split("/").pop() || "repo";
-
-  let worktree_name = config.worktrees.folder_template;
-
-  worktree_name = worktree_name
-    .replace("{{repo_name}}", repo_name)
-    .replace("{{branch_description}}", branch_state.description)
-    .replace("{{user}}", branch_state.user || "")
-    .replace("{{type}}", branch_state.type || "")
-    .replace("{{ticket}}", branch_state.ticket || "")
-    .replace("{{version}}", branch_state.version || "");
-
-  worktree_name = worktree_name
-    .replace(/\s/g, "")
-    .replace(/--+/g, "-")
-    .replace(/^-+|-+$/g, "");
-
-  const base_path = config.worktrees.base_path;
-  return `${base_path}${base_path.endsWith("/") ? "" : "/"}${worktree_name}`;
 }
 
 function get_user_from_cache(): string {

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -5,7 +5,7 @@ import { execSync } from "child_process";
 import Configstore from "configstore";
 import color from "picocolors";
 import { chdir } from "process";
-import { Output, parse } from "valibot";
+import { InferOutput, parse } from "valibot";
 import { V_BRANCH_ACTIONS } from "./valibot-consts";
 import { BranchState, CommitState, Config } from "./valibot-state";
 import { BRANCH_ACTION_OPTIONS, load_setup, get_git_root } from "./utils";
@@ -15,11 +15,11 @@ import { build_branch, build_worktree_path } from "./utils/build-branch";
 
 main(load_setup(" better-branch "));
 
-async function main(config: Output<typeof Config>) {
+async function main(config: InferOutput<typeof Config>) {
   const branch_state = parse(BranchState, {});
   chdir(get_git_root());
 
-  let checkout_type: Output<typeof V_BRANCH_ACTIONS> = "branch";
+  let checkout_type: InferOutput<typeof V_BRANCH_ACTIONS> = "branch";
   if (config.worktrees.enable) {
     const branch_or_worktree = await p.select({
       message: `Checkout a branch or create a worktree?`,

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -2,10 +2,9 @@
 
 import Configstore from "configstore";
 import { chdir } from "process";
-import { InferOutput, parse } from "valibot";
+import { InferOutput, ValiError, parse } from "valibot";
 import { BranchState, CommitState, Config } from "./valibot-state";
 import { load_setup, get_git_root, NOOP_PROMPT_CACHE } from "./utils";
-import { flags } from "./args";
 import { BranchRunnable } from "./prompts/branch-runnable";
 import { BranchCheckoutPrompt } from "./prompts/branch-checkout.prompt";
 import { BranchUserPrompt } from "./prompts/branch-user.prompt";
@@ -15,8 +14,8 @@ import { BranchVersionPrompt } from "./prompts/branch-version.prompt";
 import { BranchDescriptionPrompt } from "./prompts/branch-description.prompt";
 import { BranchConfirmPrompt } from "./prompts/branch-confirm.prompt";
 import { branch_flags } from "./branch-args";
-
-main(load_setup(" better-branch "));
+import { create_strict_branch_state } from "./utils/no-interactive-validation";
+import * as p from "@clack/prompts";
 
 type PromptCtor = new (
   config: InferOutput<typeof Config>,
@@ -34,14 +33,30 @@ const promptCtors: PromptCtor[] = [
   BranchConfirmPrompt,
 ];
 
+main(load_setup(" better-branch "));
+
 async function main(config: InferOutput<typeof Config>) {
   chdir(get_git_root());
 
   const branch_state = parse(BranchState, branch_flags.branch_state);
+
+  if (!branch_flags.interactive) {
+    try {
+      parse(create_strict_branch_state(config), branch_state);
+    } catch (err) {
+      if (err instanceof ValiError) {
+        p.log.error(`Invalid branch input: ${err.message}`);
+      } else {
+        p.log.error(`Failed to validate branch input: ${err}`);
+      }
+      process.exit(0);
+    }
+  }
+
   const prompt_cache = config.cache_last_value
     ? new Configstore("better-commits")
     : NOOP_PROMPT_CACHE;
-  const prompts_to_run = flags.interactive
+  const prompts_to_run = branch_flags.interactive
     ? promptCtors
     : [BranchConfirmPrompt];
   for (const Prompt of prompts_to_run) {

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -14,6 +14,7 @@ import { BranchTicketPrompt } from "./prompts/branch-ticket.prompt";
 import { BranchVersionPrompt } from "./prompts/branch-version.prompt";
 import { BranchDescriptionPrompt } from "./prompts/branch-description.prompt";
 import { BranchConfirmPrompt } from "./prompts/branch-confirm.prompt";
+import { branch_flags } from "./branch-args";
 
 main(load_setup(" better-branch "));
 
@@ -36,7 +37,7 @@ const promptCtors: PromptCtor[] = [
 async function main(config: InferOutput<typeof Config>) {
   chdir(get_git_root());
 
-  const branch_state = parse(BranchState, {});
+  const branch_state = parse(BranchState, branch_flags.branch_state);
   const prompt_cache = config.cache_last_value
     ? new Configstore("better-commits")
     : NOOP_PROMPT_CACHE;

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -4,7 +4,12 @@ import Configstore from "configstore";
 import { chdir } from "process";
 import { InferOutput, ValiError, parse } from "valibot";
 import { BranchState, CommitState, Config } from "./valibot-state";
-import { load_setup, get_git_root, NOOP_PROMPT_CACHE } from "./utils";
+import {
+  load_setup,
+  get_git_root,
+  NOOP_PROMPT_CACHE,
+  ConfigSource,
+} from "./utils";
 import { BranchRunnable } from "./prompts/branch-runnable";
 import { BranchCheckoutPrompt } from "./prompts/branch-checkout.prompt";
 import { BranchUserPrompt } from "./prompts/branch-user.prompt";
@@ -14,7 +19,9 @@ import { BranchVersionPrompt } from "./prompts/branch-version.prompt";
 import { BranchDescriptionPrompt } from "./prompts/branch-description.prompt";
 import { BranchConfirmPrompt } from "./prompts/branch-confirm.prompt";
 import { branch_flags } from "./branch-args";
+import { print_help_text } from "./branch-help";
 import { create_strict_branch_state } from "./utils/no-interactive-validation";
+import { get_package_version } from "./utils";
 import * as p from "@clack/prompts";
 
 type PromptCtor = new (
@@ -33,10 +40,29 @@ const promptCtors: PromptCtor[] = [
   BranchConfirmPrompt,
 ];
 
-main(load_setup(" better-branch "));
+const { config, config_source } = load_setup(
+  " better-branch ",
+  branch_flags.git_args,
+);
 
-async function main(config: InferOutput<typeof Config>) {
-  chdir(get_git_root());
+main(config, config_source);
+
+async function main(
+  config: InferOutput<typeof Config>,
+  config_source: ConfigSource,
+) {
+  chdir(get_git_root(branch_flags.git_args));
+
+  if (branch_flags.version) {
+    const version = get_package_version();
+    p.log.step("Better Commits v" + version);
+    return;
+  }
+
+  if (branch_flags.help) {
+    print_help_text(config, config_source);
+    return;
+  }
 
   const branch_state = parse(BranchState, branch_flags.branch_state);
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,0 +1,139 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import { Output } from "valibot";
+import { flags } from "./args";
+import { infer_ticket_from_git, infer_type_from_git } from "./utils/infer";
+import { Config } from "./valibot-state";
+import color from "picocolors";
+
+const ADDITIONAL_COMMAND_DEFINITIONS: Record<string, string> = {
+  "better-branch": "Create a branch or worktree from a guided prompt flow.",
+  "better-commits-init":
+    "Create a .better-commits.json config in this repository.",
+};
+
+const CLI_FLAG_DEFINITIONS: Record<string, string> = {
+  "--interactive": "Run in interactive prompt mode (default behavior).",
+  "--dry-run": "Print the commit command without creating a commit.",
+  "--help": "Show help information and exit.",
+};
+
+const COMMIT_FLAG_DEFINITIONS: Record<string, string> = {
+  "--type": "Set commit type (for example feat, fix, docs).",
+  "--scope": "Set commit scope.",
+  "--title": "Set commit title/description.",
+  "--body": "Set commit body text.",
+  "--closes": "Set issue/ticket id for a closes footer.",
+  "--ticket": "Set ticket value used in the title.",
+  "--trailer": "Set trailer footer value.",
+  "--deprecates": "Set issue/ticket id for a deprecates footer.",
+  "--breaking-title": "Set breaking-change title footer.",
+  "--breaking-body": "Set breaking-change body footer.",
+  "--deprecates-title": "Set deprecates footer title text.",
+  "--deprecates-body": "Set deprecates footer body text.",
+  "--custom-footer": "Set a custom footer line.",
+};
+
+const GIT_FLAG_DEFINITIONS: Record<string, string> = {
+  "--git-dir": "Set the path to the .git directory.",
+  "--work-tree": "Set the path to the working tree root.",
+};
+
+function to_definition_lines(definitions: Record<string, string>): string {
+  const description_column = 26;
+  const minimum_spacing = 2;
+  const indent = " ";
+
+  return Object.entries(definitions)
+    .map(([name, description]) => {
+      const spaces = Math.max(
+        minimum_spacing,
+        description_column - name.length,
+      );
+      return `${indent}${name}${" ".repeat(spaces)}${description}`;
+    })
+    .join("\n");
+}
+
+export function print_help_text(
+  config: Output<typeof Config>,
+  config_source: "repository" | "global" | "none",
+) {
+  let version = "unknown";
+  try {
+    const package_json = JSON.parse(
+      fs.readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { version?: string };
+    version = package_json.version ?? version;
+  } catch {
+    // noop
+  }
+
+  let branch = "(none)";
+  try {
+    branch =
+      execSync(`git ${flags.git_args} branch --show-current`, { stdio: "pipe" })
+        .toString()
+        .trim() || "(none)";
+  } catch {
+    // noop
+  }
+
+  const inferred_type =
+    infer_type_from_git(config.commit_type.options, flags.git_args) ||
+    "Unknown";
+  const inferred_ticket = config.check_ticket.infer_ticket
+    ? infer_ticket_from_git(
+        {
+          append_hashtag: config.check_ticket.append_hashtag,
+          prepend_hashtag: config.check_ticket.prepend_hashtag,
+        },
+        flags.git_args,
+      ) || "Unknown"
+    : "Infer Disabled";
+
+  const types = config.commit_type.options
+    .map((option) => option.value)
+    .join(", ")
+    .trim();
+  const scopes = config.commit_scope.options
+    .map((option) => option.value)
+    .join(", ")
+    .trim();
+  const cli_flags = to_definition_lines(CLI_FLAG_DEFINITIONS);
+  const git_flags = to_definition_lines(GIT_FLAG_DEFINITIONS);
+  const commit_flags = to_definition_lines(COMMIT_FLAG_DEFINITIONS);
+  const additional_commands = to_definition_lines(
+    ADDITIONAL_COMMAND_DEFINITIONS,
+  );
+
+  console.log(`
+${color.green(" better-commits")} ${color.gray("v" + version)}
+
+${color.gray("BRANCH")} 
+ ${branch}
+ ${color.gray("Type")} ${color.blue(inferred_type)} ${color.gray("·")} ${color.gray("Ticket")} ${color.magenta(inferred_ticket)}
+
+${color.gray("CONFIGURATION")} 
+ ${config_source}
+
+${color.gray("Types")} 
+ ${types}
+
+${color.gray("Scopes")} 
+ ${scopes}
+
+${color.gray("CLI FLAGS")} 
+${cli_flags}
+
+${color.gray("Commit Flags")} 
+${commit_flags}
+
+${color.gray("Git Flags")} 
+${git_flags}
+
+${color.gray("ADDITIONAL COMMANDS")} 
+${additional_commands}
+
+`);
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
 import fs from "fs";
-import { Output } from "valibot";
+import { InferOutput } from "valibot";
 import { flags } from "./args";
 import { infer_ticket_from_git, infer_type_from_git } from "./utils/infer";
 import { Config } from "./valibot-state";
@@ -56,7 +56,7 @@ function to_definition_lines(definitions: Record<string, string>): string {
 }
 
 export function print_help_text(
-  config: Output<typeof Config>,
+  config: InferOutput<typeof Config>,
   config_source: "repository" | "global" | "none",
 ) {
   let version = "unknown";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 #! /usr/bin/env node
 
 import { chdir } from "process";
-import { Output, parse } from "valibot";
+import * as p from "@clack/prompts";
+import { Input, Output, ValiError, parse } from "valibot";
 import { CommitState, Config } from "./valibot-state";
 import { load_setup, get_git_root, NOOP_PROMPT_CACHE } from "./utils";
+import { create_strict_commit_state } from "./utils/no-interactive-validation";
 import Configstore from "configstore";
 import { CommitTypePrompt } from "./prompts/commit-type.prompt";
 import { Runnable } from "./prompts/runnable";
@@ -14,6 +16,8 @@ import { CommitBodyPrompt } from "./prompts/commit-body.prompt";
 import { CommitFooterPrompt } from "./prompts/commit-footer.prompt";
 import { CommitConfirmPrompt } from "./prompts/commit-confirm.prompt";
 import { CommitStatusPrompt } from "./prompts/commit-status.prompt";
+import { flags } from "./args";
+import { infer_ticket_from_git, infer_type_from_git } from "./utils/infer";
 
 type PromptCtor = new (
   config: Output<typeof Config>,
@@ -34,14 +38,66 @@ const promptCtors: PromptCtor[] = [
 
 main(load_setup());
 
+// TODO: Hypothetically, we could just do this, then remove code from prompts?
+function infer_not_interactive(config: Output<typeof Config>) {
+  if (flags.interactive) return;
+
+  let inferred_state = { ticket: "", type: "" };
+
+  if (config.check_ticket.infer_ticket) {
+    const inferred_ticket = infer_ticket_from_git(
+      {
+        append_hashtag: config.check_ticket.append_hashtag,
+        prepend_hashtag: config.check_ticket.prepend_hashtag,
+      },
+      flags.git_args,
+    );
+    inferred_state.ticket = inferred_ticket;
+  }
+
+  const inferred_type = infer_type_from_git(
+    config.commit_type.options,
+    flags.git_args,
+  );
+  inferred_state.type = inferred_type;
+
+  return inferred_state;
+}
+
 export async function main(config: Output<typeof Config>) {
   chdir(get_git_root());
-  const commit_state = parse(CommitState, {});
+
+  const infer_state = infer_not_interactive(config);
+  const flags_plus_infer: Input<typeof CommitState> = {
+    ...flags.commit_state,
+    type: (flags.commit_state.type || infer_state?.type) ?? "",
+    ticket: (flags.commit_state.ticket || infer_state?.ticket) ?? "",
+  };
+
+  const commit_state = parse(CommitState, flags_plus_infer);
+
+  if (!flags.interactive) {
+    try {
+      parse(create_strict_commit_state(config), commit_state);
+    } catch (err) {
+      if (err instanceof ValiError) {
+        p.log.error(`Invalid --no-interactive commit input: ${err.message}`);
+      } else {
+        p.log.error(`Failed to validate --no-interactive commit input: ${err}`);
+      }
+      process.exit(0);
+    }
+  }
+
   const prompt_cache = config.cache_last_value
     ? new Configstore("better-commits")
     : NOOP_PROMPT_CACHE;
 
-  for (const Prompt of promptCtors) {
+  const prompts_to_run = flags.interactive
+    ? promptCtors
+    : [CommitConfirmPrompt];
+
+  for (const Prompt of prompts_to_run) {
     await new Prompt(config, commit_state, prompt_cache).run();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,17 @@
 #! /usr/bin/env node
 
+import fs from "fs";
 import { chdir } from "process";
 import * as p from "@clack/prompts";
 import { Input, Output, ValiError, parse } from "valibot";
 import { CommitState, Config } from "./valibot-state";
-import { load_setup, get_git_root, NOOP_PROMPT_CACHE } from "./utils";
+import {
+  CONFIG_FILE_NAME,
+  load_setup,
+  get_default_config_path,
+  get_git_root,
+  NOOP_PROMPT_CACHE,
+} from "./utils";
 import { create_strict_commit_state } from "./utils/no-interactive-validation";
 import Configstore from "configstore";
 import { CommitTypePrompt } from "./prompts/commit-type.prompt";
@@ -17,7 +24,8 @@ import { CommitFooterPrompt } from "./prompts/commit-footer.prompt";
 import { CommitConfirmPrompt } from "./prompts/commit-confirm.prompt";
 import { CommitStatusPrompt } from "./prompts/commit-status.prompt";
 import { flags } from "./args";
-import { infer_ticket_from_git, infer_type_from_git } from "./utils/infer";
+import { infer_not_interactive } from "./utils/infer";
+import { print_help_text } from "./help";
 
 type PromptCtor = new (
   config: Output<typeof Config>,
@@ -36,36 +44,27 @@ const promptCtors: PromptCtor[] = [
   CommitConfirmPrompt,
 ];
 
-main(load_setup());
+const root = get_git_root();
+const has_repo_config = fs.existsSync(`${root}/${CONFIG_FILE_NAME}`);
+const has_global_config = fs.existsSync(get_default_config_path());
+const config_source = has_repo_config
+  ? "repository"
+  : has_global_config
+    ? "global"
+    : "none";
 
-// TODO: Hypothetically, we could just do this, then remove code from prompts?
-function infer_not_interactive(config: Output<typeof Config>) {
-  if (flags.interactive) return;
+main(load_setup(), config_source);
 
-  let inferred_state = { ticket: "", type: "" };
-
-  if (config.check_ticket.infer_ticket) {
-    const inferred_ticket = infer_ticket_from_git(
-      {
-        append_hashtag: config.check_ticket.append_hashtag,
-        prepend_hashtag: config.check_ticket.prepend_hashtag,
-      },
-      flags.git_args,
-    );
-    inferred_state.ticket = inferred_ticket;
-  }
-
-  const inferred_type = infer_type_from_git(
-    config.commit_type.options,
-    flags.git_args,
-  );
-  inferred_state.type = inferred_type;
-
-  return inferred_state;
-}
-
-export async function main(config: Output<typeof Config>) {
+export async function main(
+  config: Output<typeof Config>,
+  config_source: "repository" | "global" | "none",
+) {
   chdir(get_git_root());
+
+  if (flags.help) {
+    print_help_text(config, config_source);
+    return;
+  }
 
   const infer_state = infer_not_interactive(config);
   const flags_plus_infer: Input<typeof CommitState> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import fs from "fs";
 import { chdir } from "process";
 import * as p from "@clack/prompts";
-import { Input, Output, ValiError, parse } from "valibot";
+import { InferInput, InferOutput, ValiError, parse } from "valibot";
 import { CommitState, Config } from "./valibot-state";
 import {
   CONFIG_FILE_NAME,
@@ -28,8 +28,8 @@ import { infer_not_interactive } from "./utils/infer";
 import { print_help_text } from "./help";
 
 type PromptCtor = new (
-  config: Output<typeof Config>,
-  commit_state: Output<typeof CommitState>,
+  config: InferOutput<typeof Config>,
+  commit_state: InferOutput<typeof CommitState>,
   prompt_cache: Configstore,
 ) => Runnable;
 
@@ -56,7 +56,7 @@ const config_source = has_repo_config
 main(load_setup(), config_source);
 
 export async function main(
-  config: Output<typeof Config>,
+  config: InferOutput<typeof Config>,
   config_source: "repository" | "global" | "none",
 ) {
   chdir(get_git_root());
@@ -67,7 +67,7 @@ export async function main(
   }
 
   const infer_state = infer_not_interactive(config);
-  const flags_plus_infer: Input<typeof CommitState> = {
+  const flags_plus_infer: InferInput<typeof CommitState> = {
     ...flags.commit_state,
     type: (flags.commit_state.type || infer_state?.type) ?? "",
     ticket: (flags.commit_state.ticket || infer_state?.ticket) ?? "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,14 @@
 #! /usr/bin/env node
 
-import fs from "fs";
 import { chdir } from "process";
 import * as p from "@clack/prompts";
 import { InferInput, InferOutput, ValiError, parse } from "valibot";
 import { CommitState, Config } from "./valibot-state";
 import {
-  CONFIG_FILE_NAME,
   load_setup,
-  get_default_config_path,
   get_git_root,
   NOOP_PROMPT_CACHE,
+  ConfigSource,
 } from "./utils";
 import { create_strict_commit_state } from "./utils/no-interactive-validation";
 import Configstore from "configstore";
@@ -24,6 +22,7 @@ import { CommitFooterPrompt } from "./prompts/commit-footer.prompt";
 import { CommitConfirmPrompt } from "./prompts/commit-confirm.prompt";
 import { CommitStatusPrompt } from "./prompts/commit-status.prompt";
 import { flags } from "./args";
+import { get_package_version } from "./utils";
 import { infer_not_interactive } from "./utils/infer";
 import { print_help_text } from "./help";
 
@@ -44,22 +43,21 @@ const promptCtors: PromptCtor[] = [
   CommitConfirmPrompt,
 ];
 
-const root = get_git_root();
-const has_repo_config = fs.existsSync(`${root}/${CONFIG_FILE_NAME}`);
-const has_global_config = fs.existsSync(get_default_config_path());
-const config_source = has_repo_config
-  ? "repository"
-  : has_global_config
-    ? "global"
-    : "none";
+const { config, config_source } = load_setup();
 
-main(load_setup(), config_source);
+main(config, config_source);
 
 export async function main(
   config: InferOutput<typeof Config>,
-  config_source: "repository" | "global" | "none",
+  config_source: ConfigSource,
 ) {
   chdir(get_git_root());
+
+  if (flags.version) {
+    const version = get_package_version();
+    p.log.step("Better Commits v" + version);
+    return;
+  }
 
   if (flags.help) {
     print_help_text(config, config_source);

--- a/src/prompts/branch-checkout.prompt.ts
+++ b/src/prompts/branch-checkout.prompt.ts
@@ -27,10 +27,10 @@ export class BranchCheckoutPrompt extends BranchRunnable {
   }
 
   get #initival_values() {
-    return this.config.branch_action_default;
+    return this.branch_state.checkout || this.config.branch_action_default;
   }
 
   #post_run_effects(value: InferOutput<typeof V_BRANCH_ACTIONS>) {
-    this.branch_state.checkout_type = value;
+    this.branch_state.checkout = value;
   }
 }

--- a/src/prompts/branch-checkout.prompt.ts
+++ b/src/prompts/branch-checkout.prompt.ts
@@ -1,0 +1,36 @@
+import { InferOutput } from "valibot";
+import { BranchRunnable } from "./branch-runnable";
+import { V_BRANCH_ACTIONS } from "../valibot-consts";
+import * as p from "@clack/prompts";
+import { BRANCH_ACTION_OPTIONS } from "../utils";
+
+export class BranchCheckoutPrompt extends BranchRunnable {
+  async run(): Promise<void> {
+    if (this.#is_enabled) {
+      const branch_or_worktree = await p.select({
+        message: this.#message,
+        initialValue: this.#initival_values,
+        options: BRANCH_ACTION_OPTIONS,
+      });
+
+      if (p.isCancel(branch_or_worktree)) process.exit();
+      this.#post_run_effects(branch_or_worktree);
+    }
+  }
+
+  get #message() {
+    return `Checkout a branch or create a worktree?`;
+  }
+
+  get #is_enabled() {
+    return this.config.worktrees.enable;
+  }
+
+  get #initival_values() {
+    return this.config.branch_action_default;
+  }
+
+  #post_run_effects(value: InferOutput<typeof V_BRANCH_ACTIONS>) {
+    this.branch_state.checkout_type = value;
+  }
+}

--- a/src/prompts/branch-confirm.prompt.ts
+++ b/src/prompts/branch-confirm.prompt.ts
@@ -2,7 +2,7 @@ import * as p from "@clack/prompts";
 import { execSync } from "child_process";
 import color from "picocolors";
 import { chdir } from "process";
-import { flags } from "../args";
+import { branch_flags } from "../branch-args";
 import { get_git_root } from "../utils";
 import { build_branch, build_worktree_path } from "../utils/build-branch";
 import { BranchRunnable } from "./branch-runnable";
@@ -47,9 +47,12 @@ export class BranchConfirmPrompt extends BranchRunnable {
 
     if (!this.#is_worktree) {
       try {
-        execSync(`git ${flags.git_args} checkout ${branch_flag} ${branch_name}`, {
-          stdio: "inherit",
-        });
+        execSync(
+          `git ${branch_flags.git_args} checkout ${branch_flag} ${branch_name}`,
+          {
+            stdio: "inherit",
+          },
+        );
         p.log.info(
           `Switched to a new branch '${color.bgGreen(
             " " + color.black(branch_name) + " ",
@@ -66,11 +69,14 @@ export class BranchConfirmPrompt extends BranchRunnable {
       const worktree_name = build_worktree_path(
         this.branch_state,
         this.config,
-        get_git_root(),
+        get_git_root(branch_flags.git_args),
       );
-      execSync(`git worktree add ${worktree_name} ${branch_flag} ${branch_name}`, {
-        stdio: "inherit",
-      });
+      execSync(
+        `git ${branch_flags.git_args} worktree add ${worktree_name} ${branch_flag} ${branch_name}`,
+        {
+          stdio: "inherit",
+        },
+      );
       p.log.info(
         `Created a new worktree ${color.bgGreen(
           " " + color.black(worktree_name) + " ",
@@ -110,7 +116,9 @@ export class BranchConfirmPrompt extends BranchRunnable {
     // TODO: There has to be a better way 🤦
     let branch_flag = "";
     try {
-      execSync(`git show-ref ${branch_name}`, { encoding: "utf-8" });
+      execSync(`git ${branch_flags.git_args} show-ref ${branch_name}`, {
+        encoding: "utf-8",
+      });
       p.log.warning(
         color.yellow(
           `${branch_name} already exists! Checking out existing branch.`,

--- a/src/prompts/branch-confirm.prompt.ts
+++ b/src/prompts/branch-confirm.prompt.ts
@@ -15,7 +15,7 @@ export class BranchConfirmPrompt extends BranchRunnable {
   }
 
   get #is_worktree(): boolean {
-    return this.branch_state.checkout_type === "worktree";
+    return this.branch_state.checkout === "worktree";
   }
 
   get #pre_commands(): string[] {

--- a/src/prompts/branch-confirm.prompt.ts
+++ b/src/prompts/branch-confirm.prompt.ts
@@ -1,0 +1,126 @@
+import * as p from "@clack/prompts";
+import { execSync } from "child_process";
+import color from "picocolors";
+import { chdir } from "process";
+import { flags } from "../args";
+import { get_git_root } from "../utils";
+import { build_branch, build_worktree_path } from "../utils/build-branch";
+import { BranchRunnable } from "./branch-runnable";
+
+export class BranchConfirmPrompt extends BranchRunnable {
+  async run(): Promise<void> {
+    this.#run_pre_commands();
+    this.#run_checkout();
+    this.#run_post_commands();
+  }
+
+  get #is_worktree(): boolean {
+    return this.branch_state.checkout_type === "worktree";
+  }
+
+  get #pre_commands(): string[] {
+    return this.#is_worktree
+      ? this.config.worktree_pre_commands
+      : this.config.branch_pre_commands;
+  }
+
+  get #post_commands(): string[] {
+    return this.#is_worktree
+      ? this.config.worktree_post_commands
+      : this.config.branch_post_commands;
+  }
+
+  get #branch_name(): string {
+    return build_branch(this.branch_state, this.config);
+  }
+
+  #run_pre_commands(): void {
+    this.#run_commands(
+      this.#pre_commands,
+      "Something went wrong when executing pre-commands: ",
+    );
+  }
+
+  #run_checkout(): void {
+    const branch_name = this.#branch_name;
+    const branch_flag = this.#verify_branch_name(branch_name);
+
+    if (!this.#is_worktree) {
+      try {
+        execSync(`git ${flags.git_args} checkout ${branch_flag} ${branch_name}`, {
+          stdio: "inherit",
+        });
+        p.log.info(
+          `Switched to a new branch '${color.bgGreen(
+            " " + color.black(branch_name) + " ",
+          )}'`,
+        );
+      } catch (err) {
+        process.exit(0);
+      }
+
+      return;
+    }
+
+    try {
+      const worktree_name = build_worktree_path(
+        this.branch_state,
+        this.config,
+        get_git_root(),
+      );
+      execSync(`git worktree add ${worktree_name} ${branch_flag} ${branch_name}`, {
+        stdio: "inherit",
+      });
+      p.log.info(
+        `Created a new worktree ${color.bgGreen(
+          " " + color.black(worktree_name) + " ",
+        )}, checked out branch ${color.bgGreen(
+          " " + color.black(branch_name) + " ",
+        )}`,
+      );
+      p.log.info(
+        color.bgMagenta(color.black(` cd ${worktree_name} `)) +
+          " to navigate to your new worktree",
+      );
+      chdir(worktree_name);
+    } catch (err) {
+      process.exit(0);
+    }
+  }
+
+  #run_post_commands(): void {
+    this.#run_commands(
+      this.#post_commands,
+      "Something went wrong when executing post-commands: ",
+    );
+  }
+
+  #run_commands(commands: string[], error_message: string): void {
+    commands.forEach((command) => {
+      try {
+        execSync(command, { stdio: "inherit" });
+      } catch (err) {
+        p.log.error(error_message + err);
+        process.exit(0);
+      }
+    });
+  }
+
+  #verify_branch_name(branch_name: string): string {
+    // TODO: There has to be a better way 🤦
+    let branch_flag = "";
+    try {
+      execSync(`git show-ref ${branch_name}`, { encoding: "utf-8" });
+      p.log.warning(
+        color.yellow(
+          `${branch_name} already exists! Checking out existing branch.`,
+        ),
+      );
+    } catch (err) {
+      // Branch does not exist
+      branch_flag = "-b";
+    }
+
+    return branch_flag;
+  }
+}

--- a/src/prompts/branch-description.prompt.ts
+++ b/src/prompts/branch-description.prompt.ts
@@ -1,0 +1,36 @@
+import * as p from "@clack/prompts";
+import { BranchRunnable } from "./branch-runnable";
+
+export class BranchDescriptionPrompt extends BranchRunnable {
+  async run(): Promise<void> {
+    const description = await p.text({
+      message: this.#message,
+      placeholder: "",
+      validate: (value) => this.#validate(value),
+    });
+
+    if (p.isCancel(description)) process.exit(0);
+    this.#run_post_effects(description ?? "");
+  }
+
+  get #message(): string {
+    return "Type a short description";
+  }
+
+  get #max_length(): number {
+    return this.config.branch_description.max_length;
+  }
+
+  #validate(value: string | undefined): string | undefined {
+    if (!value) return "Please enter a description";
+    if (value.length > this.#max_length) {
+      return `Exceeded max length. Description max [${this.#max_length}]`;
+    }
+  }
+
+  #run_post_effects(prompt_result: string): void {
+    this.branch_state.description = prompt_result
+      .replace(/\s+/g, "-")
+      .toLowerCase();
+  }
+}

--- a/src/prompts/branch-description.prompt.ts
+++ b/src/prompts/branch-description.prompt.ts
@@ -7,6 +7,7 @@ export class BranchDescriptionPrompt extends BranchRunnable {
       message: this.#message,
       placeholder: "",
       validate: (value) => this.#validate(value),
+      initialValue: this.branch_state.description,
     });
 
     if (p.isCancel(description)) process.exit(0);

--- a/src/prompts/branch-runnable.ts
+++ b/src/prompts/branch-runnable.ts
@@ -1,0 +1,13 @@
+import { InferOutput } from "valibot";
+import { BranchState, Config } from "../valibot-state";
+import Configstore from "configstore";
+
+export abstract class BranchRunnable {
+  constructor(
+    protected config: InferOutput<typeof Config>,
+    protected branch_state: InferOutput<typeof BranchState>,
+    protected prompt_cache: Configstore,
+  ) {}
+
+  abstract run(): Promise<void>;
+}

--- a/src/prompts/branch-ticket.prompt.ts
+++ b/src/prompts/branch-ticket.prompt.ts
@@ -10,6 +10,7 @@ export class BranchTicketPrompt extends BranchRunnable {
       message: this.#message,
       placeholder: "",
       validate: (value) => this.#validate(value),
+      initialValue: this.branch_state.ticket,
     });
 
     if (p.isCancel(ticket)) process.exit(0);

--- a/src/prompts/branch-ticket.prompt.ts
+++ b/src/prompts/branch-ticket.prompt.ts
@@ -1,0 +1,40 @@
+import * as p from "@clack/prompts";
+import { optional_message } from "../utils/messages";
+import { BranchRunnable } from "./branch-runnable";
+
+export class BranchTicketPrompt extends BranchRunnable {
+  async run(): Promise<void> {
+    if (!this.#is_enabled) return;
+
+    const ticket = await p.text({
+      message: this.#message,
+      placeholder: "",
+      validate: (value) => this.#validate(value),
+    });
+
+    if (p.isCancel(ticket)) process.exit(0);
+    this.#run_post_effects(ticket ?? "");
+  }
+
+  get #is_enabled(): boolean {
+    return this.config.branch_ticket.enable;
+  }
+
+  get #is_required(): boolean {
+    return this.config.branch_ticket.required;
+  }
+
+  get #message(): string {
+    return this.#is_required
+      ? "Type ticket / issue number"
+      : optional_message("Type ticket / issue number");
+  }
+
+  #validate(value: string | undefined): string | undefined {
+    if (this.#is_required && !value) return "Please enter a ticket / issue";
+  }
+
+  #run_post_effects(prompt_result: string): void {
+    this.branch_state.ticket = prompt_result;
+  }
+}

--- a/src/prompts/branch-type.prompt.ts
+++ b/src/prompts/branch-type.prompt.ts
@@ -24,7 +24,7 @@ export class BranchTypePrompt extends BranchRunnable {
   }
 
   get #initial_value(): string {
-    return this.config.commit_type.initial_value;
+    return this.branch_state.type || this.config.commit_type.initial_value;
   }
 
   get #options(): {

--- a/src/prompts/branch-type.prompt.ts
+++ b/src/prompts/branch-type.prompt.ts
@@ -1,0 +1,43 @@
+import * as p from "@clack/prompts";
+import { BranchRunnable } from "./branch-runnable";
+
+export class BranchTypePrompt extends BranchRunnable {
+  async run(): Promise<void> {
+    if (!this.#is_enabled) return;
+
+    const branch_type = await p.select({
+      message: this.#message,
+      initialValue: this.#initial_value,
+      options: this.#options,
+    });
+
+    if (p.isCancel(branch_type)) process.exit(0);
+    this.#run_post_effects(branch_type);
+  }
+
+  get #is_enabled(): boolean {
+    return this.config.branch_type.enable;
+  }
+
+  get #message(): string {
+    return "Select a branch type";
+  }
+
+  get #initial_value(): string {
+    return this.config.commit_type.initial_value;
+  }
+
+  get #options(): {
+    label?: string | undefined;
+    value: string;
+    emoji?: string;
+    hint?: string;
+    trailer?: string;
+  }[] {
+    return this.config.commit_type.options;
+  }
+
+  #run_post_effects(prompt_result: string): void {
+    this.branch_state.type = prompt_result;
+  }
+}

--- a/src/prompts/branch-user.prompt.ts
+++ b/src/prompts/branch-user.prompt.ts
@@ -33,7 +33,10 @@ export class BranchUserPrompt extends BranchRunnable {
   }
 
   get #initial_value(): string {
-    return get_value_from_cache(this.prompt_cache, "username");
+    return (
+      this.branch_state.user ||
+      get_value_from_cache(this.prompt_cache, "username")
+    );
   }
 
   #validate(value: string | undefined): string | undefined {

--- a/src/prompts/branch-user.prompt.ts
+++ b/src/prompts/branch-user.prompt.ts
@@ -1,0 +1,47 @@
+import * as p from "@clack/prompts";
+import { get_value_from_cache, set_value_cache } from "../utils";
+import { optional_message } from "../utils/messages";
+import { BranchRunnable } from "./branch-runnable";
+
+export class BranchUserPrompt extends BranchRunnable {
+  async run(): Promise<void> {
+    if (!this.#is_enabled) return;
+
+    const user_name = await p.text({
+      message: this.#message,
+      placeholder: "",
+      initialValue: this.#initial_value,
+      validate: (value) => this.#validate(value),
+    });
+
+    if (p.isCancel(user_name)) process.exit(0);
+    this.#run_post_effects(user_name ?? "");
+  }
+
+  get #is_enabled(): boolean {
+    return this.config.branch_user.enable;
+  }
+
+  get #is_required(): boolean {
+    return this.config.branch_user.required;
+  }
+
+  get #message(): string {
+    return this.#is_required
+      ? "Type your git username"
+      : optional_message("Type your git username");
+  }
+
+  get #initial_value(): string {
+    return get_value_from_cache(this.prompt_cache, "username");
+  }
+
+  #validate(value: string | undefined): string | undefined {
+    if (this.#is_required && !value) return "Please enter a username";
+  }
+
+  #run_post_effects(prompt_result: string): void {
+    this.branch_state.user = prompt_result.replace(/\s+/g, "-").toLowerCase();
+    set_value_cache(this.prompt_cache, "username", this.branch_state.user);
+  }
+}

--- a/src/prompts/branch-version.prompt.ts
+++ b/src/prompts/branch-version.prompt.ts
@@ -10,6 +10,7 @@ export class BranchVersionPrompt extends BranchRunnable {
       message: this.#message,
       placeholder: "",
       validate: (value) => this.#validate(value),
+      initialValue: this.branch_state.version,
     });
 
     if (p.isCancel(version)) process.exit(0);

--- a/src/prompts/branch-version.prompt.ts
+++ b/src/prompts/branch-version.prompt.ts
@@ -1,0 +1,40 @@
+import * as p from "@clack/prompts";
+import { optional_message } from "../utils/messages";
+import { BranchRunnable } from "./branch-runnable";
+
+export class BranchVersionPrompt extends BranchRunnable {
+  async run(): Promise<void> {
+    if (!this.#is_enabled) return;
+
+    const version = await p.text({
+      message: this.#message,
+      placeholder: "",
+      validate: (value) => this.#validate(value),
+    });
+
+    if (p.isCancel(version)) process.exit(0);
+    this.#run_post_effects(version ?? "");
+  }
+
+  get #is_enabled(): boolean {
+    return this.config.branch_version.enable;
+  }
+
+  get #is_required(): boolean {
+    return this.config.branch_version.required;
+  }
+
+  get #message(): string {
+    return this.#is_required
+      ? "Type version number"
+      : optional_message("Type version number");
+  }
+
+  #validate(value: string | undefined): string | undefined {
+    if (this.#is_required && !value) return "Please enter a version";
+  }
+
+  #run_post_effects(prompt_result: string): void {
+    this.branch_state.version = prompt_result;
+  }
+}

--- a/src/prompts/commit-confirm.prompt.ts
+++ b/src/prompts/commit-confirm.prompt.ts
@@ -1,9 +1,9 @@
 import * as p from "@clack/prompts";
-import color from "picocolors";
 import { StdioOptions, execSync } from "child_process";
 import { flags } from "../args";
 import { Runnable } from "./runnable";
 import { dry_run_message } from "../utils/messages";
+import { build_commit_string } from "../utils/build-commit-string";
 
 export class CommitConfirmPrompt extends Runnable {
   async run(): Promise<void> {
@@ -14,7 +14,9 @@ export class CommitConfirmPrompt extends Runnable {
 
     if (this.#print_commit_output) {
       p.note(
-        this.#build_commit_string({
+        build_commit_string({
+          commit_state: this.commit_state,
+          config: this.config,
           colorize: true,
           escape_quotes: false,
           include_trailer: true,
@@ -80,7 +82,9 @@ export class CommitConfirmPrompt extends Runnable {
   }
 
   get #commit_command(): string {
-    return `git ${flags.git_args} commit -m "${this.#build_commit_string({
+    return `git ${flags.git_args} commit -m "${build_commit_string({
+      commit_state: this.commit_state,
+      config: this.config,
       colorize: false,
       escape_quotes: true,
       include_trailer: false,
@@ -111,166 +115,5 @@ export class CommitConfirmPrompt extends Runnable {
     const user_name = this.prompt_cache.get("username");
     this.prompt_cache.clear();
     if (user_name) this.prompt_cache.set("username", user_name);
-  }
-
-  #build_commit_string({
-    colorize = false,
-    escape_quotes = false,
-    include_trailer = false,
-  }: {
-    colorize?: boolean;
-    escape_quotes?: boolean;
-    include_trailer?: boolean;
-  }): string {
-    let commit_string = "";
-    if (this.commit_state.type) {
-      commit_string += colorize
-        ? color.blue(this.commit_state.type)
-        : this.commit_state.type;
-    }
-
-    if (this.commit_state.scope) {
-      const scope = colorize
-        ? color.cyan(this.commit_state.scope)
-        : this.commit_state.scope;
-      commit_string += `(${scope})`;
-    }
-
-    let title_ticket = this.commit_state.ticket;
-    const surround = this.config.check_ticket.surround;
-    if (this.commit_state.ticket && surround) {
-      const open_token = surround.charAt(0);
-      const close_token = surround.charAt(1);
-      title_ticket = `${open_token}${this.commit_state.ticket}${close_token}`;
-    }
-
-    const position_beginning =
-      this.config.check_ticket.title_position === "beginning";
-    if (
-      title_ticket &&
-      this.config.check_ticket.add_to_title &&
-      position_beginning
-    ) {
-      commit_string = `${colorize ? color.magenta(title_ticket) : title_ticket} ${commit_string}`;
-    }
-
-    const position_before_colon =
-      this.config.check_ticket.title_position === "before-colon";
-    if (
-      title_ticket &&
-      this.config.check_ticket.add_to_title &&
-      position_before_colon
-    ) {
-      const spacing =
-        this.commit_state.scope ||
-        (this.commit_state.type && !this.config.check_ticket.surround)
-          ? " "
-          : "";
-      commit_string += colorize
-        ? color.magenta(spacing + title_ticket)
-        : spacing + title_ticket;
-    }
-
-    if (
-      this.commit_state.breaking_title &&
-      this.config.breaking_change.add_exclamation_to_title
-    ) {
-      commit_string += colorize ? color.red("!") : "!";
-    }
-
-    if (
-      this.commit_state.scope ||
-      this.commit_state.type ||
-      (title_ticket && position_before_colon)
-    ) {
-      commit_string += ": ";
-    }
-
-    const position_start = this.config.check_ticket.title_position === "start";
-    const position_end = this.config.check_ticket.title_position === "end";
-    if (
-      title_ticket &&
-      this.config.check_ticket.add_to_title &&
-      position_start
-    ) {
-      commit_string += colorize
-        ? color.magenta(title_ticket) + " "
-        : title_ticket + " ";
-    }
-
-    if (this.commit_state.title) {
-      commit_string += colorize
-        ? color.reset(this.commit_state.title)
-        : this.commit_state.title;
-    }
-
-    if (title_ticket && this.config.check_ticket.add_to_title && position_end) {
-      commit_string +=
-        " " + (colorize ? color.magenta(title_ticket) : title_ticket);
-    }
-
-    if (this.commit_state.body) {
-      const temp = this.commit_state.body.split("\\n");
-      const res = temp
-        .map((value) => (colorize ? color.reset(value.trim()) : value.trim()))
-        .join("\n");
-      commit_string += `\n\n${res}`;
-    }
-
-    if (this.commit_state.breaking_title) {
-      const title = colorize
-        ? color.red(`BREAKING CHANGE: ${this.commit_state.breaking_title}`)
-        : `BREAKING CHANGE: ${this.commit_state.breaking_title}`;
-      commit_string += `\n\n${title}`;
-    }
-
-    if (this.commit_state.breaking_body) {
-      const body = colorize
-        ? color.red(this.commit_state.breaking_body)
-        : this.commit_state.breaking_body;
-      commit_string += `\n\n${body}`;
-    }
-
-    if (this.commit_state.deprecates_title) {
-      const title = colorize
-        ? color.yellow(`DEPRECATED: ${this.commit_state.deprecates_title}`)
-        : `DEPRECATED: ${this.commit_state.deprecates_title}`;
-      commit_string += `\n\n${title}`;
-    }
-
-    if (this.commit_state.deprecates_body) {
-      const body = colorize
-        ? color.yellow(this.commit_state.deprecates_body)
-        : this.commit_state.deprecates_body;
-      commit_string += `\n\n${body}`;
-    }
-
-    if (this.commit_state.custom_footer) {
-      const temp = this.commit_state.custom_footer.split("\\n");
-      const res = temp
-        .map((value) => (colorize ? color.reset(value.trim()) : value.trim()))
-        .join("\n");
-      commit_string += `\n\n${res}`;
-    }
-
-    if (this.commit_state.closes && this.commit_state.ticket) {
-      commit_string += colorize
-        ? `\n\n${color.reset(this.commit_state.closes)} ${color.magenta(this.commit_state.ticket)}`
-        : `\n\n${this.commit_state.closes} ${this.commit_state.ticket}`;
-    }
-
-    if (include_trailer && this.commit_state.trailer) {
-      commit_string += colorize
-        ? `\n\n${color.dim(this.commit_state.trailer)}`
-        : `\n\n${this.commit_state.trailer}`;
-    }
-
-    if (escape_quotes) {
-      commit_string = commit_string
-        .replaceAll('"', '\\"')
-        .replaceAll("`", "\\`");
-    }
-
-    return commit_string;
   }
 }

--- a/src/prompts/commit-confirm.prompt.ts
+++ b/src/prompts/commit-confirm.prompt.ts
@@ -3,6 +3,7 @@ import color from "picocolors";
 import { StdioOptions, execSync } from "child_process";
 import { flags } from "../args";
 import { Runnable } from "./runnable";
+import { dry_run_message } from "../utils/messages";
 
 export class CommitConfirmPrompt extends Runnable {
   async run(): Promise<void> {
@@ -29,8 +30,17 @@ export class CommitConfirmPrompt extends Runnable {
     }
 
     try {
-      p.log.info("Committing changes...");
-      execSync(this.#commit_command, this.#git_command_options);
+      p.log.info(
+        flags.dry_run
+          ? dry_run_message("Committing changes...")
+          : "Committing changes...",
+      );
+      execSync(
+        this.#commit_command,
+        flags.dry_run
+          ? this.#git_command_options_quiet
+          : this.#git_command_options,
+      );
     } catch (err) {
       p.log.error("Something went wrong when committing: " + err);
       return;
@@ -40,7 +50,7 @@ export class CommitConfirmPrompt extends Runnable {
   }
 
   get #confirm_with_editor(): boolean {
-    return this.config.confirm_with_editor;
+    return flags.interactive && this.config.confirm_with_editor;
   }
 
   get #print_commit_output(): boolean {
@@ -57,6 +67,12 @@ export class CommitConfirmPrompt extends Runnable {
       : { stdio: "inherit" as StdioOptions };
   }
 
+  get #git_command_options_quiet(): { stdio: StdioOptions; shell?: string } {
+    return this.config.overrides.shell
+      ? { shell: this.config.overrides.shell, stdio: "pipe" as StdioOptions }
+      : { stdio: "pipe" as StdioOptions };
+  }
+
   get #trailer_arg(): string {
     return this.commit_state.trailer
       ? `--trailer="${this.commit_state.trailer}"`
@@ -68,14 +84,22 @@ export class CommitConfirmPrompt extends Runnable {
       colorize: false,
       escape_quotes: true,
       include_trailer: false,
-    })}" ${this.#trailer_arg}`.trim();
+    })}" ${this.#trailer_arg} ${this.#dry_run_args}`.trim();
+  }
+
+  get #dry_run_args(): string {
+    return flags.dry_run ? "--dry-run --porcelain --untracked-files=no" : "";
   }
 
   async #get_continue_commit(): Promise<boolean> {
+    if (!flags.interactive) return true;
     if (!this.#confirm_commit) return true;
 
+    // dry_run_message
     const continue_commit = (await p.confirm({
-      message: "Confirm Commit?",
+      message: flags.dry_run
+        ? dry_run_message("Confirm Commit?")
+        : "Confirm Commit?",
     })) as boolean;
     if (p.isCancel(continue_commit)) process.exit(0);
     return continue_commit;

--- a/src/prompts/commit-footer.prompt.ts
+++ b/src/prompts/commit-footer.prompt.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import { Output } from "valibot";
+import { InferOutput } from "valibot";
 import { V_FOOTER_OPTIONS } from "../valibot-consts";
 import {
   COMMIT_FOOTER_OPTIONS,
@@ -13,7 +13,7 @@ import {
 } from "../utils/messages";
 import { Runnable } from "./runnable";
 
-type FooterOption = Output<typeof V_FOOTER_OPTIONS>;
+type FooterOption = InferOutput<typeof V_FOOTER_OPTIONS>;
 type FooterPromptOption = {
   value: FooterOption;
   label: string;

--- a/src/prompts/commit-ticket.prompt.ts
+++ b/src/prompts/commit-ticket.prompt.ts
@@ -1,16 +1,7 @@
 import * as p from "@clack/prompts";
-import { execSync } from "child_process";
 import { flags } from "../args";
-import {
-  REGEX_SLASH_NUM,
-  REGEX_SLASH_TAG,
-  REGEX_SLASH_UND,
-  REGEX_START_NUM,
-  REGEX_START_TAG,
-  REGEX_START_UND,
-  get_value_from_cache,
-  set_value_cache,
-} from "../utils";
+import { get_value_from_cache, set_value_cache } from "../utils";
+import { infer_ticket_from_git } from "../utils/infer";
 import {
   cache_message,
   inferred_message,
@@ -68,7 +59,13 @@ export class CommitTicketPrompt extends Runnable {
     }
 
     if (this.#infer_ticket_enabled) {
-      const inferred_value = this.#infer_ticket_from_branch();
+      const inferred_value = infer_ticket_from_git(
+        {
+          append_hashtag: this.config.check_ticket.append_hashtag,
+          prepend_hashtag: this.config.check_ticket.prepend_hashtag,
+        },
+        flags.git_args,
+      );
       if (inferred_value) {
         return {
           initial_value: inferred_value,
@@ -81,35 +78,5 @@ export class CommitTicketPrompt extends Runnable {
       initial_value: this.commit_state.ticket,
       message: optional_message("Add ticket / issue"),
     };
-  }
-
-  #infer_ticket_from_branch(): string {
-    try {
-      const branch = execSync(`git ${flags.git_args} branch --show-current`, {
-        stdio: "pipe",
-      }).toString();
-
-      const found: string[] = [
-        branch.match(REGEX_START_UND),
-        branch.match(REGEX_SLASH_UND),
-        branch.match(REGEX_SLASH_TAG),
-        branch.match(REGEX_SLASH_NUM),
-        branch.match(REGEX_START_TAG),
-        branch.match(REGEX_START_NUM),
-      ]
-        .filter((v) => v != null)
-        .map((v) => (v && v.length >= 2 ? v[1] : ""));
-
-      if (found.length && found[0]) {
-        return this.config.check_ticket.append_hashtag ||
-          this.config.check_ticket.prepend_hashtag === "Prompt"
-          ? "#" + found[0]
-          : found[0];
-      }
-    } catch {
-      // Can't find branch, fail silently
-    }
-
-    return "";
   }
 }

--- a/src/prompts/commit-title.prompt.ts
+++ b/src/prompts/commit-title.prompt.ts
@@ -5,6 +5,7 @@ import {
   set_value_cache,
 } from "../utils";
 import { cache_message } from "../utils/messages";
+import { get_commit_title_size } from "../utils/commit-title-size";
 import { Runnable } from "./runnable";
 
 export class CommitTitlePrompt extends Runnable {
@@ -30,8 +31,9 @@ export class CommitTitlePrompt extends Runnable {
       };
     }
 
+    // this.commit_state.title will pull from flag if populated
     return {
-      initial_value: "",
+      initial_value: this.commit_state.title,
       message: "Write a brief title describing the commit",
     };
   }
@@ -49,16 +51,16 @@ export class CommitTitlePrompt extends Runnable {
   }
 
   #get_size(value: string): number {
-    const commit_scope_size = this.commit_state.scope
-      ? this.commit_state.scope.length + 2
-      : 0;
-    const commit_type_size = this.commit_state.type.length;
-    const commit_ticket_size = this.config.check_ticket.add_to_title
-      ? this.commit_state.ticket.length
-      : 0;
-
-    return (
-      commit_scope_size + commit_type_size + commit_ticket_size + value.length
+    return get_commit_title_size(
+      {
+        type: this.commit_state.type,
+        scope: this.commit_state.scope,
+        ticket: this.commit_state.ticket,
+        title: value,
+      },
+      {
+        include_ticket: this.config.check_ticket.add_to_title,
+      },
     );
   }
 

--- a/src/prompts/commit-type.prompt.ts
+++ b/src/prompts/commit-type.prompt.ts
@@ -1,9 +1,7 @@
 import * as p from "@clack/prompts";
-import {
-  get_value_from_cache,
-  infer_type_from_branch,
-  set_value_cache,
-} from "../utils";
+import { flags } from "../args";
+import { get_value_from_cache, set_value_cache } from "../utils";
+import { infer_type_from_git } from "../utils/infer";
 import { cache_message, inferred_message } from "../utils/messages";
 import { Runnable } from "./runnable";
 
@@ -36,8 +34,10 @@ export class CommitTypePrompt extends Runnable {
       };
 
     if (this.config.commit_type.infer_type_from_branch) {
-      const options = this.#options.map((o) => o.value);
-      const type_from_branch = infer_type_from_branch(options);
+      const type_from_branch = infer_type_from_git(
+        this.#options,
+        flags.git_args,
+      );
       if (type_from_branch) {
         return {
           message: inferred_message("Commit type"),

--- a/src/prompts/runnable.ts
+++ b/src/prompts/runnable.ts
@@ -1,11 +1,11 @@
-import { Output } from "valibot";
+import { InferOutput } from "valibot";
 import { CommitState, Config } from "../valibot-state";
 import Configstore from "configstore";
 
 export abstract class Runnable {
   constructor(
-    protected config: Output<typeof Config>,
-    protected commit_state: Output<typeof CommitState>,
+    protected config: InferOutput<typeof Config>,
+    protected commit_state: InferOutput<typeof CommitState>,
     protected prompt_cache: Configstore,
   ) {}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,11 +49,19 @@ export const NOOP_PROMPT_CACHE = {
   clear: () => {},
 } as unknown as Configstore;
 
+export type ConfigSource = "repository" | "global" | "none";
+
+export type LoadedSetup = {
+  config: InferOutput<typeof Config>;
+  config_source: ConfigSource;
+};
+
 /* LOAD */
 export function load_setup(
   cli_name = " better-commits ",
-): InferOutput<typeof Config> {
-  /* console.clear(); */ /* TODO: TESTING */
+  git_args = flags.git_args,
+): LoadedSetup {
+  console.clear();
   p.intro(`${color.bgCyan(color.black(cli_name))}`);
 
   let global_config = null;
@@ -62,26 +70,32 @@ export function load_setup(
     global_config = read_config_from_path(home_path);
   }
 
-  const root = get_git_root();
+  const root = get_git_root(git_args);
   const root_path = `${root}/${CONFIG_FILE_NAME}`;
   if (fs.existsSync(root_path)) {
     p.log.step("Reading from Repository Config");
     const repo_config = read_config_from_path(root_path);
-    return global_config
-      ? {
-          ...repo_config,
-          overrides: global_config.overrides.shell
-            ? global_config.overrides
-            : repo_config.overrides,
-          confirm_with_editor: global_config.confirm_with_editor,
-          cache_last_value: global_config.cache_last_value,
-        }
-      : repo_config;
+    return {
+      config: global_config
+        ? {
+            ...repo_config,
+            overrides: global_config.overrides.shell
+              ? global_config.overrides
+              : repo_config.overrides,
+            confirm_with_editor: global_config.confirm_with_editor,
+            cache_last_value: global_config.cache_last_value,
+          }
+        : repo_config,
+      config_source: "repository",
+    };
   }
 
   if (global_config) {
     p.log.step("Reading from Global Config");
-    return global_config;
+    return {
+      config: global_config,
+      config_source: "global",
+    };
   }
 
   const default_config = parse(Config, {});
@@ -89,7 +103,10 @@ export function load_setup(
     "Config not found. Generating default .better-commit.json at $HOME",
   );
   fs.writeFileSync(home_path, JSON.stringify(default_config, null, 4));
-  return default_config;
+  return {
+    config: default_config,
+    config_source: "none",
+  };
 }
 
 function read_config_from_path(config_path: string) {
@@ -129,10 +146,10 @@ function validate_config(config: unknown): InferOutput<typeof Config> {
 /*
 rev-parse will fail in a --bare repository root
 */
-export function get_git_root(): string {
+export function get_git_root(git_args = flags.git_args): string {
   let path = ".";
   try {
-    path = execSync(`git ${flags.git_args} rev-parse --show-toplevel`)
+    path = execSync(`git ${git_args} rev-parse --show-toplevel`)
       .toString()
       .trim();
   } catch (err) {
@@ -145,6 +162,18 @@ export function get_git_root(): string {
 
 export function get_default_config_path(): string {
   return homedir() + "/" + CONFIG_FILE_NAME;
+}
+
+export function get_package_version(): string {
+  try {
+    const package_json = JSON.parse(
+      fs.readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { version?: string };
+
+    return package_json.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
 }
 
 export function addNewLine(arr: string[], i: number) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import { execSync } from "child_process";
 import fs from "fs";
 import { homedir } from "os";
 import color from "picocolors";
-import { Output, ValiError, parse } from "valibot";
+import { InferOutput, ValiError, parse } from "valibot";
 import { Config } from "./valibot-state";
 import { V_BRANCH_ACTIONS } from "./valibot-consts";
 import { flags } from "./args";
@@ -35,7 +35,7 @@ export const COMMIT_FOOTER_OPTIONS = [
   { value: "custom", label: "custom", hint: "Add a custom footer" },
 ];
 export const BRANCH_ACTION_OPTIONS: {
-  value: Output<typeof V_BRANCH_ACTIONS>;
+  value: InferOutput<typeof V_BRANCH_ACTIONS>;
   label: string;
   hint?: string;
 }[] = [
@@ -52,7 +52,7 @@ export const NOOP_PROMPT_CACHE = {
 /* LOAD */
 export function load_setup(
   cli_name = " better-commits ",
-): Output<typeof Config> {
+): InferOutput<typeof Config> {
   console.clear();
   p.intro(`${color.bgCyan(color.black(cli_name))}`);
 
@@ -104,13 +104,18 @@ function read_config_from_path(config_path: string) {
   return validate_config(res);
 }
 
-function validate_config(config: Output<typeof Config>): Output<typeof Config> {
+function validate_config(config: unknown): InferOutput<typeof Config> {
   try {
     return parse(Config, config);
   } catch (err: any) {
     if (err instanceof ValiError) {
       const first_issue_path = err.issues[0].path ?? [];
-      const dot_path = first_issue_path.map((item) => item.key).join(".");
+      const dot_path = first_issue_path
+        .map((item: { key?: unknown }) => item.key)
+        .filter((key: unknown): key is string | number =>
+          typeof key === "string" || typeof key === "number",
+        )
+        .join(".");
       p.log.error(
         `Invalid Configuration: ${color.red(dot_path)}\n` + err.message,
       );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,6 @@ import color from "picocolors";
 import { Output, ValiError, parse } from "valibot";
 import { Config } from "./valibot-state";
 import { V_BRANCH_ACTIONS } from "./valibot-consts";
-import { argv } from "process";
 import { flags } from "./args";
 import Configstore from "configstore";
 
@@ -16,18 +15,6 @@ export const A_FOR_ALL = `${color.dim(
   "(<space> to select, <a> to select all)",
 )}`;
 export const OPTIONAL_PROMPT = `${color.dim("(optional)")}`;
-export const REGEX_SLASH_TAG = new RegExp(/\/(\w+-\d+)/);
-export const REGEX_START_TAG = new RegExp(/^(\w+-\d+)/);
-export const REGEX_START_UND = new RegExp(/^([A-Z]+-[\[a-zA-Z\]\d]+)_/);
-export const REGEX_SLASH_UND = new RegExp(/\/([A-Z]+-[\[a-zA-Z\]\d]+)_/);
-
-// TODO: This might conflict with version from better-branch
-// - Maybe negative lookup against .
-// - Maybe check the order
-// - Maybe use order to split and check values
-export const REGEX_SLASH_NUM = new RegExp(/\/(\d+)/);
-export const REGEX_START_NUM = new RegExp(/^(\d+)/);
-
 export const COMMIT_FOOTER_OPTIONS = [
   {
     value: "closes",
@@ -68,8 +55,6 @@ export function load_setup(
 ): Output<typeof Config> {
   console.clear();
   p.intro(`${color.bgCyan(color.black(cli_name))}`);
-
-  set_non_configuration_arguments();
 
   let global_config = null;
   const home_path = get_default_config_path();
@@ -133,30 +118,6 @@ function validate_config(config: Output<typeof Config>): Output<typeof Config> {
 }
 /* END LOAD */
 
-export function infer_type_from_branch(types: string[]): string {
-  let branch = "";
-  try {
-    branch = execSync(`git ${flags.git_args} branch --show-current`, {
-      stdio: "pipe",
-    }).toString();
-  } catch (err) {
-    return "";
-  }
-  const found = types.find((t) => {
-    const start_dash = new RegExp(`^${t}-`);
-    const between_dash = new RegExp(`-${t}-`);
-    const before_slash = new RegExp(`${t}\/`);
-    const re = [
-      branch.match(start_dash),
-      branch.match(between_dash),
-      branch.match(before_slash),
-    ].filter((v) => v != null);
-    return re?.length;
-  });
-
-  return found ?? "";
-}
-
 /*
 rev-parse will fail in a --bare repository root
 */
@@ -189,10 +150,6 @@ export function clean_commit_title(title: string): string {
     return title_trimmed.substring(0, title_trimmed.length - 1).trim();
   }
   return title.trim();
-}
-
-function set_non_configuration_arguments() {
-  flags.git_args = `${argv[2] ?? ""} ${argv[3] ?? ""}`.trim();
 }
 
 export function get_value_from_cache(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,7 +53,7 @@ export const NOOP_PROMPT_CACHE = {
 export function load_setup(
   cli_name = " better-commits ",
 ): InferOutput<typeof Config> {
-  console.clear();
+  /* console.clear(); */ /* TODO: TESTING */
   p.intro(`${color.bgCyan(color.black(cli_name))}`);
 
   let global_config = null;
@@ -112,8 +112,9 @@ function validate_config(config: unknown): InferOutput<typeof Config> {
       const first_issue_path = err.issues[0].path ?? [];
       const dot_path = first_issue_path
         .map((item: { key?: unknown }) => item.key)
-        .filter((key: unknown): key is string | number =>
-          typeof key === "string" || typeof key === "number",
+        .filter(
+          (key: unknown): key is string | number =>
+            typeof key === "string" || typeof key === "number",
         )
         .join(".");
       p.log.error(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,14 +59,13 @@ export function load_setup(
   let global_config = null;
   const home_path = get_default_config_path();
   if (fs.existsSync(home_path)) {
-    p.log.step("Found global config");
     global_config = read_config_from_path(home_path);
   }
 
   const root = get_git_root();
   const root_path = `${root}/${CONFIG_FILE_NAME}`;
   if (fs.existsSync(root_path)) {
-    p.log.step("Found repository config");
+    p.log.step("Reading from Repository Config");
     const repo_config = read_config_from_path(root_path);
     return global_config
       ? {
@@ -80,7 +79,10 @@ export function load_setup(
       : repo_config;
   }
 
-  if (global_config) return global_config;
+  if (global_config) {
+    p.log.step("Reading from Global Config");
+    return global_config;
+  }
 
   const default_config = parse(Config, {});
   p.log.step(

--- a/src/utils/build-branch.test.ts
+++ b/src/utils/build-branch.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "valibot";
+import { BranchState, Config } from "../valibot-state";
+import { build_branch, build_worktree_path } from "./build-branch";
+
+function make_config(input: Record<string, unknown> = {}) {
+  return parse(Config, input);
+}
+
+function make_branch(input: Record<string, unknown>) {
+  return parse(BranchState, input);
+}
+
+describe("build_branch", () => {
+  it("builds branch with default order and separators", () => {
+    const branch = make_branch({
+      user: "erik",
+      version: "1.2.0",
+      type: "feat",
+      ticket: "ABC-1",
+      description: "add-parser",
+    });
+    const config = make_config();
+
+    expect(build_branch(branch, config)).toBe(
+      "erik/1.2.0/feat/ABC-1-add-parser",
+    );
+  });
+
+  it("omits empty fields without leaving trailing separators", () => {
+    const branch = make_branch({
+      user: "erik",
+      type: "fix",
+      description: "repair-parser",
+    });
+    const config = make_config();
+
+    expect(build_branch(branch, config)).toBe("erik/fix/repair-parser");
+  });
+
+  it("respects custom branch order", () => {
+    const branch = make_branch({
+      type: "feat",
+      ticket: "ABC-1",
+      description: "add-parser",
+      user: "erik",
+    });
+    const config = make_config({
+      branch_order: ["type", "ticket", "description", "user"],
+      branch_description: { separator: "/" },
+    });
+
+    expect(build_branch(branch, config)).toBe("feat/ABC-1-add-parser/erik");
+  });
+
+  it("uses per-field separator config", () => {
+    const branch = make_branch({
+      user: "erik",
+      type: "feat",
+      ticket: "ABC-1",
+      description: "parser",
+    });
+    const config = make_config({
+      branch_user: { separator: "_" },
+      branch_type: { separator: "-" },
+      branch_ticket: { separator: "_" },
+      branch_description: { separator: "" },
+      branch_order: ["user", "type", "ticket", "description"],
+    });
+
+    expect(build_branch(branch, config)).toBe("erik_feat-ABC-1_parser");
+  });
+});
+
+describe("build_worktree_path", () => {
+  it("builds path from template tokens", () => {
+    const branch = make_branch({
+      user: "erik",
+      type: "feat",
+      ticket: "ABC-1",
+      description: "add-parser",
+      version: "1.2.0",
+    });
+    const config = make_config({
+      worktrees: {
+        base_path: "../worktrees",
+        folder_template: "{{repo_name}}-{{ticket}}-{{branch_description}}",
+      },
+    });
+
+    const result = build_worktree_path(branch, config, "/tmp/my-repo");
+    expect(result).toBe("../worktrees/my-repo-ABC-1-add-parser");
+  });
+
+  it("handles base_path with trailing slash", () => {
+    const branch = make_branch({
+      description: "add-parser",
+    });
+    const config = make_config({
+      worktrees: {
+        base_path: "../wt/",
+        folder_template: "{{repo_name}}-{{branch_description}}",
+      },
+    });
+
+    const result = build_worktree_path(branch, config, "/tmp/repo");
+    expect(result).toBe("../wt/repo-add-parser");
+  });
+
+  it("normalizes repeated dashes and trims edges", () => {
+    const branch = make_branch({
+      ticket: "",
+      description: "parser",
+    });
+    const config = make_config({
+      worktrees: {
+        base_path: "../wt",
+        folder_template: "-{{repo_name}}--{{ticket}}--{{branch_description}}-",
+      },
+    });
+
+    const result = build_worktree_path(branch, config, "/tmp/repo");
+    expect(result).toBe("../wt/repo-parser");
+  });
+
+  it("removes whitespace from rendered worktree name", () => {
+    const branch = make_branch({
+      user: "erik",
+      description: "new feature",
+    });
+    const config = make_config({
+      worktrees: {
+        base_path: "../wt",
+        folder_template: "{{repo_name}}-{{user}}-{{branch_description}}",
+      },
+    });
+
+    const result = build_worktree_path(branch, config, "/tmp/repo");
+    expect(result).toBe("../wt/repo-erik-newfeature");
+  });
+});

--- a/src/utils/build-branch.ts
+++ b/src/utils/build-branch.ts
@@ -1,14 +1,14 @@
-import { Output } from "valibot";
+import { InferOutput } from "valibot";
 import { V_BRANCH_CONFIG_FIELDS, V_BRANCH_FIELDS } from "../valibot-consts";
 import { BranchState, Config } from "../valibot-state";
 
 export function build_branch(
-  branch: Output<typeof BranchState>,
-  config: Output<typeof Config>,
+  branch: InferOutput<typeof BranchState>,
+  config: InferOutput<typeof Config>,
 ): string {
   let res = "";
-  config.branch_order.forEach((b: Output<typeof V_BRANCH_FIELDS>) => {
-    const config_key: Output<typeof V_BRANCH_CONFIG_FIELDS> = `branch_${b}`;
+  config.branch_order.forEach((b: InferOutput<typeof V_BRANCH_FIELDS>) => {
+    const config_key: InferOutput<typeof V_BRANCH_CONFIG_FIELDS> = `branch_${b}`;
     if (branch[b]) res += branch[b] + config[config_key].separator;
   });
 
@@ -20,8 +20,8 @@ export function build_branch(
 }
 
 export function build_worktree_path(
-  branch_state: Output<typeof BranchState>,
-  config: Output<typeof Config>,
+  branch_state: InferOutput<typeof BranchState>,
+  config: InferOutput<typeof Config>,
   git_root: string,
 ): string {
   const repo_name = git_root.split("/").pop() || "repo";

--- a/src/utils/build-branch.ts
+++ b/src/utils/build-branch.ts
@@ -1,0 +1,46 @@
+import { Output } from "valibot";
+import { V_BRANCH_CONFIG_FIELDS, V_BRANCH_FIELDS } from "../valibot-consts";
+import { BranchState, Config } from "../valibot-state";
+
+export function build_branch(
+  branch: Output<typeof BranchState>,
+  config: Output<typeof Config>,
+): string {
+  let res = "";
+  config.branch_order.forEach((b: Output<typeof V_BRANCH_FIELDS>) => {
+    const config_key: Output<typeof V_BRANCH_CONFIG_FIELDS> = `branch_${b}`;
+    if (branch[b]) res += branch[b] + config[config_key].separator;
+  });
+
+  if (res.endsWith("-") || res.endsWith("/") || res.endsWith("_")) {
+    return res.slice(0, -1).trim();
+  }
+
+  return res.trim();
+}
+
+export function build_worktree_path(
+  branch_state: Output<typeof BranchState>,
+  config: Output<typeof Config>,
+  git_root: string,
+): string {
+  const repo_name = git_root.split("/").pop() || "repo";
+
+  let worktree_name = config.worktrees.folder_template;
+
+  worktree_name = worktree_name
+    .replace("{{repo_name}}", repo_name)
+    .replace("{{branch_description}}", branch_state.description)
+    .replace("{{user}}", branch_state.user || "")
+    .replace("{{type}}", branch_state.type || "")
+    .replace("{{ticket}}", branch_state.ticket || "")
+    .replace("{{version}}", branch_state.version || "");
+
+  worktree_name = worktree_name
+    .replace(/\s/g, "")
+    .replace(/--+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  const base_path = config.worktrees.base_path;
+  return `${base_path}${base_path.endsWith("/") ? "" : "/"}${worktree_name}`;
+}

--- a/src/utils/build-commit-string.test.ts
+++ b/src/utils/build-commit-string.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { Output, parse } from "valibot";
+import { InferOutput, parse } from "valibot";
 import { CommitState, Config } from "../valibot-state";
 import { build_commit_string } from "./build-commit-string";
 
-type ConfigOutput = Output<typeof Config>;
+type ConfigOutput = InferOutput<typeof Config>;
 type ConfigOverrides = Partial<
   Omit<ConfigOutput, "check_ticket" | "breaking_change">
 > & {

--- a/src/utils/build-commit-string.test.ts
+++ b/src/utils/build-commit-string.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import { Output, parse } from "valibot";
+import { CommitState, Config } from "../valibot-state";
+import { build_commit_string } from "./build-commit-string";
+
+type ConfigOutput = Output<typeof Config>;
+type ConfigOverrides = Partial<
+  Omit<ConfigOutput, "check_ticket" | "breaking_change">
+> & {
+  check_ticket?: Partial<ConfigOutput["check_ticket"]>;
+  breaking_change?: Partial<ConfigOutput["breaking_change"]>;
+};
+
+function make_config(overrides?: ConfigOverrides): ConfigOutput {
+  const base = parse_config({});
+  if (!overrides) return base;
+
+  return {
+    ...base,
+    ...overrides,
+    check_ticket: {
+      ...base.check_ticket,
+      ...(overrides.check_ticket ?? {}),
+    },
+    breaking_change: {
+      ...base.breaking_change,
+      ...(overrides.breaking_change ?? {}),
+    },
+  };
+}
+
+function parse_config(input: Record<string, unknown>) {
+  return parse(Config, input);
+}
+
+function make_state(input: Record<string, unknown>) {
+  return parse(CommitState, input);
+}
+
+describe("build_commit_string", () => {
+  it("builds a basic conventional commit title", () => {
+    const result = build_commit_string({
+      commit_state: make_state({
+        type: "feat",
+        scope: "api",
+        title: "add endpoint",
+      }),
+      config: make_config(),
+    });
+
+    expect(result).toBe("feat(api): add endpoint");
+  });
+
+  it("adds ticket at start of title by default", () => {
+    const result = build_commit_string({
+      commit_state: make_state({
+        type: "fix",
+        title: "handle null values",
+        ticket: "ABC-123",
+      }),
+      config: make_config(),
+    });
+
+    expect(result).toBe("fix: ABC-123 handle null values");
+  });
+
+  it("supports ticket before colon", () => {
+    const result = build_commit_string({
+      commit_state: make_state({
+        type: "feat",
+        scope: "core",
+        title: "ship parser",
+        ticket: "PROJ-9",
+      }),
+      config: make_config({
+        check_ticket: {
+          title_position: "before-colon",
+        },
+      }),
+    });
+
+    expect(result).toBe("feat(core) PROJ-9: ship parser");
+  });
+
+  it("supports ticket wrapping when surround is configured", () => {
+    const result = build_commit_string({
+      commit_state: make_state({
+        type: "chore",
+        title: "update docs",
+        ticket: "42",
+      }),
+      config: make_config({
+        check_ticket: {
+          surround: "[]",
+        },
+      }),
+    });
+
+    expect(result).toBe("chore: [42] update docs");
+  });
+
+  it("supports ticket at end of title", () => {
+    const result = build_commit_string({
+      commit_state: make_state({
+        type: "chore",
+        title: "cleanup docs",
+        ticket: "DOC-7",
+      }),
+      config: make_config({
+        check_ticket: {
+          title_position: "end",
+        },
+      }),
+    });
+
+    expect(result).toBe("chore: cleanup docs DOC-7");
+  });
+
+  it("supports ticket at beginning of commit header", () => {
+    const result = build_commit_string({
+      commit_state: make_state({
+        type: "feat",
+        scope: "api",
+        title: "add endpoint",
+        ticket: "ABC-1",
+      }),
+      config: make_config({
+        check_ticket: {
+          title_position: "beginning",
+        },
+      }),
+    });
+
+    expect(result).toBe("ABC-1 feat(api): add endpoint");
+  });
+
+  it("appends body and footer blocks with spacing", () => {
+    const result = build_commit_string({
+      commit_state: make_state({
+        type: "feat",
+        title: "add cli",
+        body: "line 1\\nline 2",
+        custom_footer: "Refs: ABC-1",
+      }),
+      config: make_config(),
+    });
+
+    expect(result).toBe("feat: add cli\n\nline 1\nline 2\n\nRefs: ABC-1");
+  });
+
+  it("includes trailer only when include_trailer is true", () => {
+    const state = make_state({
+      type: "feat",
+      title: "add cli",
+      trailer: "Signed-off-by: Erik",
+    });
+    const config = make_config();
+
+    const no_trailer = build_commit_string({
+      commit_state: state,
+      config,
+      include_trailer: false,
+    });
+    const with_trailer = build_commit_string({
+      commit_state: state,
+      config,
+      include_trailer: true,
+    });
+
+    expect(no_trailer).toBe("feat: add cli");
+    expect(with_trailer).toBe("feat: add cli\n\nSigned-off-by: Erik");
+  });
+
+  it("skips title ticket when add_to_title is false but keeps closes footer", () => {
+    const result = build_commit_string({
+      commit_state: make_state({
+        type: "fix",
+        title: "repair parser",
+        ticket: "BUG-99",
+        closes: "closes",
+      }),
+      config: make_config({
+        check_ticket: {
+          add_to_title: false,
+        },
+      }),
+    });
+
+    expect(result).toBe("fix: repair parser\n\ncloses BUG-99");
+  });
+
+  it("adds breaking exclamation when enabled", () => {
+    const result = build_commit_string({
+      commit_state: make_state({
+        type: "feat",
+        title: "replace api",
+        breaking_title: "v1 removed",
+      }),
+      config: make_config({
+        breaking_change: {
+          add_exclamation_to_title: true,
+        },
+      }),
+    });
+
+    expect(result).toBe("feat!: replace api\n\nBREAKING CHANGE: v1 removed");
+  });
+
+  it("renders deprecation title and body blocks", () => {
+    const result = build_commit_string({
+      commit_state: make_state({
+        type: "chore",
+        title: "remove legacy helper",
+        deprecates_title: "legacy helper",
+        deprecates_body: "use modern helper",
+      }),
+      config: make_config(),
+    });
+
+    expect(result).toBe(
+      "chore: remove legacy helper\n\nDEPRECATED: legacy helper\n\nuse modern helper",
+    );
+  });
+
+  it("formats before-colon ticket without type and scope", () => {
+    const result = build_commit_string({
+      commit_state: make_state({
+        title: "ship parser",
+        ticket: "PROJ-9",
+      }),
+      config: make_config({
+        check_ticket: {
+          title_position: "before-colon",
+        },
+      }),
+    });
+
+    expect(result).toBe("PROJ-9: ship parser");
+  });
+
+  it("escapes double quotes and backticks for shell-safe command composition", () => {
+    const result = build_commit_string({
+      commit_state: make_state({
+        type: "fix",
+        title: 'handle "quoted" `inline` value',
+      }),
+      config: make_config(),
+      escape_quotes: true,
+    });
+
+    expect(result).toBe('fix: handle \\"quoted\\" \\`inline\\` value');
+  });
+});

--- a/src/utils/build-commit-string.ts
+++ b/src/utils/build-commit-string.ts
@@ -1,10 +1,10 @@
 import color from "picocolors";
-import { Output } from "valibot";
+import { InferOutput } from "valibot";
 import { CommitState, Config } from "../valibot-state";
 
 type BuildCommitStringInput = {
-  commit_state: Output<typeof CommitState>;
-  config: Output<typeof Config>;
+  commit_state: InferOutput<typeof CommitState>;
+  config: InferOutput<typeof Config>;
   colorize?: boolean;
   escape_quotes?: boolean;
   include_trailer?: boolean;

--- a/src/utils/build-commit-string.ts
+++ b/src/utils/build-commit-string.ts
@@ -1,0 +1,158 @@
+import color from "picocolors";
+import { Output } from "valibot";
+import { CommitState, Config } from "../valibot-state";
+
+type BuildCommitStringInput = {
+  commit_state: Output<typeof CommitState>;
+  config: Output<typeof Config>;
+  colorize?: boolean;
+  escape_quotes?: boolean;
+  include_trailer?: boolean;
+};
+
+export function build_commit_string({
+  commit_state,
+  config,
+  colorize = false,
+  escape_quotes = false,
+  include_trailer = false,
+}: BuildCommitStringInput): string {
+  let commit_string = "";
+  if (commit_state.type) {
+    commit_string += colorize
+      ? color.blue(commit_state.type)
+      : commit_state.type;
+  }
+
+  if (commit_state.scope) {
+    const scope = colorize
+      ? color.cyan(commit_state.scope)
+      : commit_state.scope;
+    commit_string += `(${scope})`;
+  }
+
+  let title_ticket = commit_state.ticket;
+  const surround = config.check_ticket.surround;
+  if (commit_state.ticket && surround) {
+    const open_token = surround.charAt(0);
+    const close_token = surround.charAt(1);
+    title_ticket = `${open_token}${commit_state.ticket}${close_token}`;
+  }
+
+  const position_beginning = config.check_ticket.title_position === "beginning";
+  if (title_ticket && config.check_ticket.add_to_title && position_beginning) {
+    commit_string = `${colorize ? color.magenta(title_ticket) : title_ticket} ${commit_string}`;
+  }
+
+  const position_before_colon =
+    config.check_ticket.title_position === "before-colon";
+  if (
+    title_ticket &&
+    config.check_ticket.add_to_title &&
+    position_before_colon
+  ) {
+    const spacing =
+      commit_state.scope || (commit_state.type && !config.check_ticket.surround)
+        ? " "
+        : "";
+    commit_string += colorize
+      ? color.magenta(spacing + title_ticket)
+      : spacing + title_ticket;
+  }
+
+  if (
+    commit_state.breaking_title &&
+    config.breaking_change.add_exclamation_to_title
+  ) {
+    commit_string += colorize ? color.red("!") : "!";
+  }
+
+  if (
+    commit_state.scope ||
+    commit_state.type ||
+    (title_ticket && position_before_colon)
+  ) {
+    commit_string += ": ";
+  }
+
+  const position_start = config.check_ticket.title_position === "start";
+  const position_end = config.check_ticket.title_position === "end";
+  if (title_ticket && config.check_ticket.add_to_title && position_start) {
+    commit_string += colorize
+      ? color.magenta(title_ticket) + " "
+      : title_ticket + " ";
+  }
+
+  if (commit_state.title) {
+    commit_string += colorize
+      ? color.reset(commit_state.title)
+      : commit_state.title;
+  }
+
+  if (title_ticket && config.check_ticket.add_to_title && position_end) {
+    commit_string +=
+      " " + (colorize ? color.magenta(title_ticket) : title_ticket);
+  }
+
+  if (commit_state.body) {
+    const temp = commit_state.body.split("\\n");
+    const res = temp
+      .map((value) => (colorize ? color.reset(value.trim()) : value.trim()))
+      .join("\n");
+    commit_string += `\n\n${res}`;
+  }
+
+  if (commit_state.breaking_title) {
+    const title = colorize
+      ? color.red(`BREAKING CHANGE: ${commit_state.breaking_title}`)
+      : `BREAKING CHANGE: ${commit_state.breaking_title}`;
+    commit_string += `\n\n${title}`;
+  }
+
+  if (commit_state.breaking_body) {
+    const body = colorize
+      ? color.red(commit_state.breaking_body)
+      : commit_state.breaking_body;
+    commit_string += `\n\n${body}`;
+  }
+
+  if (commit_state.deprecates_title) {
+    const title = colorize
+      ? color.yellow(`DEPRECATED: ${commit_state.deprecates_title}`)
+      : `DEPRECATED: ${commit_state.deprecates_title}`;
+    commit_string += `\n\n${title}`;
+  }
+
+  if (commit_state.deprecates_body) {
+    const body = colorize
+      ? color.yellow(commit_state.deprecates_body)
+      : commit_state.deprecates_body;
+    commit_string += `\n\n${body}`;
+  }
+
+  if (commit_state.custom_footer) {
+    const temp = commit_state.custom_footer.split("\\n");
+    const res = temp
+      .map((value) => (colorize ? color.reset(value.trim()) : value.trim()))
+      .join("\n");
+    commit_string += `\n\n${res}`;
+  }
+
+  if (commit_state.closes && commit_state.ticket) {
+    commit_string += colorize
+      ? `\n\n${color.reset(commit_state.closes)} ${color.magenta(commit_state.ticket)}`
+      : `\n\n${commit_state.closes} ${commit_state.ticket}`;
+  }
+
+  if (include_trailer && commit_state.trailer) {
+    commit_string += colorize
+      ? `\n\n${color.dim(commit_state.trailer)}`
+      : `\n\n${commit_state.trailer}`;
+  }
+
+  if (escape_quotes) {
+    commit_string = commit_string.replaceAll('"', '\\"').replaceAll("`", "\\`");
+  }
+
+  return commit_string;
+}

--- a/src/utils/commit-title-size.ts
+++ b/src/utils/commit-title-size.ts
@@ -1,0 +1,24 @@
+type CommitTitleSizeInput = {
+  type?: string;
+  scope?: string;
+  ticket?: string;
+  title?: string;
+};
+
+type CommitTitleSizeOptions = {
+  include_ticket: boolean;
+};
+
+export function get_commit_title_size(
+  val: CommitTitleSizeInput,
+  options: CommitTitleSizeOptions,
+): number {
+  const commit_scope_size = val.scope ? val.scope.length + 2 : 0;
+  const commit_type_size = val.type?.length ?? 0;
+  const commit_ticket_size = options.include_ticket
+    ? (val.ticket?.length ?? 0)
+    : 0;
+  const title_size = val.title?.length ?? 0;
+
+  return commit_scope_size + commit_type_size + commit_ticket_size + title_size;
+}

--- a/src/utils/infer.test.ts
+++ b/src/utils/infer.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock("../args", () => ({
+  flags: {
+    interactive: false,
+    git_args: "--git-dir=/tmp/repo/.git --work-tree=/tmp/repo",
+  },
+}));
+
+import { execSync } from "child_process";
+import { parse } from "valibot";
+import { Config } from "../valibot-state";
+import {
+  infer_not_interactive,
+  infer_ticket_from_git,
+  infer_type_from_git,
+} from "./infer";
+
+const execSyncMock = vi.mocked(execSync);
+
+describe("infer", () => {
+  beforeEach(() => {
+    execSyncMock.mockReset();
+  });
+
+  it('prepends hashtags for inferred tickets when prepend_hashtag is "Always"', () => {
+    execSyncMock.mockReturnValue(Buffer.from("feat/127-cli-bombshell-args\n"));
+
+    const result = infer_ticket_from_git(
+      {
+        append_hashtag: false,
+        prepend_hashtag: "Always",
+      },
+      "--git-dir=/tmp/repo/.git --work-tree=/tmp/repo",
+    );
+
+    expect(result).toBe("#127");
+  });
+
+  it('returns plain inferred tickets when prepend_hashtag is "Never"', () => {
+    execSyncMock.mockReturnValue(Buffer.from("feat/ABC-123-add-parser\n"));
+
+    const result = infer_ticket_from_git(
+      {
+        append_hashtag: false,
+        prepend_hashtag: "Never",
+      },
+      "--git-dir=/tmp/repo/.git --work-tree=/tmp/repo",
+    );
+
+    expect(result).toBe("ABC-123");
+  });
+
+  it("infers commit types from the current branch", () => {
+    execSyncMock.mockReturnValue(Buffer.from("everduin94/feat/ABC-123-add-parser\n"));
+
+    const result = infer_type_from_git(
+      [{ value: "feat" }, { value: "fix" }],
+      "--git-dir=/tmp/repo/.git --work-tree=/tmp/repo",
+    );
+
+    expect(result).toBe("feat");
+  });
+
+  it("builds no-interactive inferred state using current config settings", () => {
+    execSyncMock.mockReturnValue(Buffer.from("feat/127-cli-bombshell-args\n"));
+
+    const config = parse(Config, {
+      check_ticket: {
+        prepend_hashtag: "Always",
+      },
+    });
+
+    expect(infer_not_interactive(config)).toEqual({
+      ticket: "#127",
+      type: "feat",
+    });
+  });
+});

--- a/src/utils/infer.ts
+++ b/src/utils/infer.ts
@@ -1,0 +1,85 @@
+import { execSync } from "child_process";
+
+type PrependHashtag = "Never" | "Always" | "Prompt";
+
+const REGEX_SLASH_TAG = /\/(\w+-\d+)/;
+const REGEX_START_TAG = /^(\w+-\d+)/;
+const REGEX_START_UND = /^([A-Z]+-[\[a-zA-Z\]\d]+)_/;
+const REGEX_SLASH_UND = /\/([A-Z]+-[\[a-zA-Z\]\d]+)_/;
+const REGEX_SLASH_NUM = /\/(\d+)/;
+const REGEX_START_NUM = /^(\d+)/;
+
+export function infer_type_from_git(
+  options: { value: string }[],
+  git_args: string,
+): string {
+  const branch = get_current_branch(git_args);
+  if (!branch) return "";
+
+  return infer_type_from_branch(
+    branch,
+    options.map((option) => option.value),
+  );
+}
+
+export function infer_ticket_from_git(
+  options: { append_hashtag: boolean; prepend_hashtag: PrependHashtag },
+  git_args: string,
+): string {
+  const branch = get_current_branch(git_args);
+  if (!branch) return "";
+
+  return infer_ticket_from_branch(branch, options);
+}
+
+function infer_ticket_from_branch(
+  branch: string,
+  options: { append_hashtag: boolean; prepend_hashtag: PrependHashtag },
+): string {
+  const found: string[] = [
+    branch.match(REGEX_START_UND),
+    branch.match(REGEX_SLASH_UND),
+    branch.match(REGEX_SLASH_TAG),
+    branch.match(REGEX_SLASH_NUM),
+    branch.match(REGEX_START_TAG),
+    branch.match(REGEX_START_NUM),
+  ]
+    .filter((value) => value != null)
+    .map((value) => (value && value.length >= 2 ? value[1] : ""));
+
+  if (!found.length || !found[0]) return "";
+
+  return options.append_hashtag || options.prepend_hashtag === "Prompt"
+    ? `#${found[0]}`
+    : found[0];
+}
+
+function infer_type_from_branch(branch: string, types: string[]): string {
+  const found = types.find((type) => {
+    const start_dash = new RegExp(`^${type}-`);
+    const between_dash = new RegExp(`-${type}-`);
+    const before_slash = new RegExp(`${type}/`);
+
+    const matches = [
+      branch.match(start_dash),
+      branch.match(between_dash),
+      branch.match(before_slash),
+    ].filter((value) => value != null);
+
+    return matches.length > 0;
+  });
+
+  return found ?? "";
+}
+
+function get_current_branch(git_args: string): string {
+  try {
+    return execSync(`git ${git_args} branch --show-current`, {
+      stdio: "pipe",
+    })
+      .toString()
+      .trim();
+  } catch {
+    return "";
+  }
+}

--- a/src/utils/infer.ts
+++ b/src/utils/infer.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
 import { flags } from "../args";
-import { Output } from "valibot";
+import { InferOutput } from "valibot";
 import { Config } from "../valibot-state";
 
 type PrependHashtag = "Never" | "Always" | "Prompt";
@@ -13,7 +13,7 @@ const REGEX_SLASH_NUM = /\/(\d+)/;
 const REGEX_START_NUM = /^(\d+)/;
 
 // TODO: Hypothetically, we could just do this, then remove code from prompts?
-export function infer_not_interactive(config: Output<typeof Config>) {
+export function infer_not_interactive(config: InferOutput<typeof Config>) {
   if (flags.interactive) return;
 
   let inferred_state = { ticket: "", type: "" };
@@ -78,7 +78,7 @@ function infer_ticket_from_branch(
 
   if (!found.length || !found[0]) return "";
 
-  return options.append_hashtag || options.prepend_hashtag === "Prompt"
+  return options.append_hashtag || options.prepend_hashtag === "Always"
     ? `#${found[0]}`
     : found[0];
 }

--- a/src/utils/infer.ts
+++ b/src/utils/infer.ts
@@ -1,4 +1,7 @@
 import { execSync } from "child_process";
+import { flags } from "../args";
+import { Output } from "valibot";
+import { Config } from "../valibot-state";
 
 type PrependHashtag = "Never" | "Always" | "Prompt";
 
@@ -8,6 +11,32 @@ const REGEX_START_UND = /^([A-Z]+-[\[a-zA-Z\]\d]+)_/;
 const REGEX_SLASH_UND = /\/([A-Z]+-[\[a-zA-Z\]\d]+)_/;
 const REGEX_SLASH_NUM = /\/(\d+)/;
 const REGEX_START_NUM = /^(\d+)/;
+
+// TODO: Hypothetically, we could just do this, then remove code from prompts?
+export function infer_not_interactive(config: Output<typeof Config>) {
+  if (flags.interactive) return;
+
+  let inferred_state = { ticket: "", type: "" };
+
+  if (config.check_ticket.infer_ticket) {
+    const inferred_ticket = infer_ticket_from_git(
+      {
+        append_hashtag: config.check_ticket.append_hashtag,
+        prepend_hashtag: config.check_ticket.prepend_hashtag,
+      },
+      flags.git_args,
+    );
+    inferred_state.ticket = inferred_ticket;
+  }
+
+  const inferred_type = infer_type_from_git(
+    config.commit_type.options,
+    flags.git_args,
+  );
+  inferred_state.type = inferred_type;
+
+  return inferred_state;
+}
 
 export function infer_type_from_git(
   options: { value: string }[],

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -19,3 +19,7 @@ export function space_to_select_message(message: string): string {
 export function a_for_all_message(message: string): string {
   return `${message} ${color.dim("· <space> to select | <a> to select all")}`;
 }
+
+export function dry_run_message(message: string): string {
+  return `${message} ${color.dim("· dry run - changes will not be committed")}`;
+}

--- a/src/utils/no-interactive-branch-validation.test.ts
+++ b/src/utils/no-interactive-branch-validation.test.ts
@@ -28,6 +28,21 @@ describe("create_strict_branch_state", () => {
     expect(result.description).toBe("add-parser");
   });
 
+  it('defaults checkout to "branch" when omitted', () => {
+    const config = make_config();
+    const schema = create_strict_branch_state(config);
+
+    const result = parse(
+      schema,
+      make_state({
+        type: "feat",
+        description: "add-parser",
+      }),
+    );
+
+    expect(result.checkout).toBe("branch");
+  });
+
   it("rejects types that are not in config.commit_type.options", () => {
     const config = make_config();
     const schema = create_strict_branch_state(config);
@@ -111,7 +126,7 @@ describe("create_strict_branch_state", () => {
           description: "add-parser",
         }),
       ),
-    ).toThrow(/Missing --version/);
+    ).toThrow(/Missing --branch-version/);
   });
 
   it("rejects missing user when branch_user.required is enabled", () => {

--- a/src/utils/no-interactive-branch-validation.test.ts
+++ b/src/utils/no-interactive-branch-validation.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "valibot";
+import { BranchState, Config } from "../valibot-state";
+import { create_strict_branch_state } from "./no-interactive-validation";
+
+function make_config(input: Record<string, unknown> = {}) {
+  return parse(Config, input);
+}
+
+function make_state(input: Record<string, unknown>) {
+  return parse(BranchState, input);
+}
+
+describe("create_strict_branch_state", () => {
+  it("accepts valid parsed branch state input", () => {
+    const config = make_config();
+    const schema = create_strict_branch_state(config);
+
+    const result = parse(
+      schema,
+      make_state({
+        type: "feat",
+        description: "add-parser",
+      }),
+    );
+
+    expect(result.type).toBe("feat");
+    expect(result.description).toBe("add-parser");
+  });
+
+  it("rejects types that are not in config.commit_type.options", () => {
+    const config = make_config();
+    const schema = create_strict_branch_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "unknown",
+          description: "add-parser",
+        }),
+      ),
+    ).toThrow(/Invalid --type "unknown"/);
+  });
+
+  it("rejects missing descriptions", () => {
+    const config = make_config();
+    const schema = create_strict_branch_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "feat",
+        }),
+      ),
+    ).toThrow(/Missing --description/);
+  });
+
+  it("rejects descriptions that exceed branch_description.max_length", () => {
+    const config = make_config({
+      branch_description: {
+        max_length: 5,
+      },
+    });
+    const schema = create_strict_branch_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "feat",
+          description: "too-long",
+        }),
+      ),
+    ).toThrow(/Description exceeds max length/);
+  });
+
+  it("rejects missing ticket when branch_ticket.required is enabled", () => {
+    const config = make_config({
+      branch_ticket: {
+        required: true,
+      },
+    });
+    const schema = create_strict_branch_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "feat",
+          description: "add-parser",
+        }),
+      ),
+    ).toThrow(/Missing --ticket/);
+  });
+
+  it("rejects missing version when branch_version.required is enabled", () => {
+    const config = make_config({
+      branch_version: {
+        required: true,
+      },
+    });
+    const schema = create_strict_branch_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "feat",
+          description: "add-parser",
+        }),
+      ),
+    ).toThrow(/Missing --version/);
+  });
+
+  it("rejects missing user when branch_user.required is enabled", () => {
+    const config = make_config({
+      branch_user: {
+        required: true,
+      },
+    });
+    const schema = create_strict_branch_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "feat",
+          description: "add-parser",
+        }),
+      ),
+    ).toThrow(/Missing --user/);
+  });
+
+  it("allows worktree checkout even when worktrees are disabled", () => {
+    const config = make_config({
+      worktrees: {
+        enable: false,
+      },
+    });
+    const schema = create_strict_branch_state(config);
+
+    const result = parse(
+      schema,
+      make_state({
+        type: "feat",
+        description: "add-parser",
+        checkout: "worktree",
+      }),
+    );
+
+    expect(result.checkout).toBe("worktree");
+  });
+});

--- a/src/utils/no-interactive-validation.test.ts
+++ b/src/utils/no-interactive-validation.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "valibot";
+import { CommitState, Config } from "../valibot-state";
+import { create_strict_commit_state } from "./no-interactive-validation";
+
+function make_config(input: Record<string, unknown> = {}) {
+  return parse(Config, input);
+}
+
+function make_state(input: Record<string, unknown>) {
+  return parse(CommitState, input);
+}
+
+describe("create_strict_commit_state", () => {
+  it("accepts valid parsed commit state input", () => {
+    const config = make_config();
+    const schema = create_strict_commit_state(config);
+
+    const result = parse(
+      schema,
+      make_state({
+        type: "feat",
+        title: "add parser",
+      }),
+    );
+
+    expect(result.type).toBe("feat");
+    expect(result.title).toBe("add parser");
+  });
+
+  it("rejects types that are not in config.commit_type.options", () => {
+    const config = make_config();
+    const schema = create_strict_commit_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "unknown",
+          title: "add parser",
+        }),
+      ),
+    ).toThrow(/Invalid --type "unknown"/);
+  });
+
+  it("allows custom scopes when custom_scope is enabled", () => {
+    const config = make_config({
+      commit_scope: {
+        custom_scope: true,
+        initial_value: "custom",
+        options: [{ value: "app", label: "app" }],
+      },
+    });
+    const schema = create_strict_commit_state(config);
+
+    const result = parse(
+      schema,
+      make_state({
+        type: "feat",
+        scope: "custom-auth",
+        title: "add parser",
+      }),
+    );
+
+    expect(result.scope).toBe("custom-auth");
+  });
+
+  it("rejects scopes outside configured options when custom_scope is disabled", () => {
+    const config = make_config({
+      commit_scope: {
+        custom_scope: false,
+        options: [{ value: "app", label: "app" }],
+      },
+    });
+    const schema = create_strict_commit_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "feat",
+          scope: "custom-auth",
+          title: "add parser",
+        }),
+      ),
+    ).toThrow(/Invalid --scope "custom-auth"/);
+  });
+
+  it("rejects missing body when commit_body.required is enabled", () => {
+    const config = make_config({
+      commit_body: {
+        required: true,
+      },
+    });
+    const schema = create_strict_commit_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "feat",
+          title: "add parser",
+        }),
+      ),
+    ).toThrow(/Missing --body/);
+  });
+
+  it("rejects titles that exceed commit_title.max_size", () => {
+    const config = make_config({
+      commit_title: {
+        max_size: 10,
+      },
+    });
+    const schema = create_strict_commit_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "feat",
+          title: "too long title",
+        }),
+      ),
+    ).toThrow(/Title exceeds max width/);
+  });
+
+  it("rejects closes footers without a ticket", () => {
+    const config = make_config();
+    const schema = create_strict_commit_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "feat",
+          title: "add parser",
+          closes: "Closes:",
+        }),
+      ),
+    ).toThrow(/--closes requires --ticket/);
+  });
+
+  it("rejects breaking bodies without breaking titles", () => {
+    const config = make_config();
+    const schema = create_strict_commit_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "feat",
+          title: "add parser",
+          breaking_body: "migration needed",
+        }),
+      ),
+    ).toThrow(/--breaking-body requires --breaking-title/);
+  });
+
+  it("rejects deprecates bodies without deprecates titles", () => {
+    const config = make_config();
+    const schema = create_strict_commit_state(config);
+
+    expect(() =>
+      parse(
+        schema,
+        make_state({
+          type: "feat",
+          title: "add parser",
+          deprecates_body: "use the new api",
+        }),
+      ),
+    ).toThrow(/--deprecates-body requires --deprecates-title/);
+  });
+});

--- a/src/utils/no-interactive-validation.ts
+++ b/src/utils/no-interactive-validation.ts
@@ -1,5 +1,9 @@
 import * as v from "valibot";
-import { COMMIT_STATE_ENTRIES, Config } from "../valibot-state";
+import {
+  BRANCH_STATE_ENTRIES,
+  COMMIT_STATE_ENTRIES,
+  Config,
+} from "../valibot-state";
 import { get_commit_title_size } from "./commit-title-size";
 
 function format_allowed_values(values: string[]): string {
@@ -106,6 +110,79 @@ export function create_strict_commit_state(
         addIssue({
           message:
             "Invalid deprecation values: --deprecates-body requires --deprecates-title.",
+        });
+      }
+    }),
+  );
+}
+
+export function create_strict_branch_state(
+  config: v.InferOutput<typeof Config>,
+) {
+  const type_values = config.commit_type.options.map((option) => option.value);
+
+  return v.pipe(
+    v.object(BRANCH_STATE_ENTRIES),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (!dataset.typed) return;
+
+      const received = dataset.value.type ? `"${dataset.value.type}"` : "(empty)";
+      if (dataset.value.type && !type_values.includes(dataset.value.type)) {
+        addIssue({
+          message: `Invalid --type ${received}. Valid types: ${format_allowed_values(type_values)}.`,
+        });
+      }
+    }),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (!dataset.typed || dataset.value.description.trim()) return;
+
+      addIssue({
+        message:
+          "Missing --description. Provide a non-empty branch description.",
+      });
+    }),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (!dataset.typed) return;
+
+      const description = dataset.value.description.trim();
+      if (description.length > config.branch_description.max_length) {
+        addIssue({
+          message: `Description exceeds max length. Current length is ${description.length}, max is ${config.branch_description.max_length}.`,
+        });
+      }
+    }),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (
+        dataset.typed &&
+        config.branch_user.required &&
+        !dataset.value.user.trim()
+      ) {
+        addIssue({
+          message: "Missing --user. branch_user.required is enabled in config.",
+        });
+      }
+    }),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (
+        dataset.typed &&
+        config.branch_ticket.required &&
+        !dataset.value.ticket.trim()
+      ) {
+        addIssue({
+          message:
+            "Missing --ticket. branch_ticket.required is enabled in config.",
+        });
+      }
+    }),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (
+        dataset.typed &&
+        config.branch_version.required &&
+        !dataset.value.version.trim()
+      ) {
+        addIssue({
+          message:
+            "Missing --version. branch_version.required is enabled in config.",
         });
       }
     }),

--- a/src/utils/no-interactive-validation.ts
+++ b/src/utils/no-interactive-validation.ts
@@ -10,70 +10,104 @@ function format_allowed_values(values: string[]): string {
 }
 
 export function create_strict_commit_state(
-  config: v.Output<typeof Config>,
-): v.ObjectSchema<typeof COMMIT_STATE_ENTRIES, undefined> {
+  config: v.InferOutput<typeof Config>,
+) {
   const type_values = config.commit_type.options.map((option) => option.value);
   const scope_values = config.commit_scope.options.map(
     (option) => option.value,
   );
 
-  return v.object(COMMIT_STATE_ENTRIES, [
-    v.custom(
-      (state) => !state.type || type_values.includes(state.type),
-      (ctx) => {
-        const input = ctx.input as { type?: string };
-        const received = input.type ? `"${input.type}"` : "(empty)";
-        return `Invalid --type ${received}. Valid types: ${format_allowed_values(type_values)}.`;
-      },
-    ),
-    v.custom(
-      (state) =>
-        !state.scope ||
-        config.commit_scope.custom_scope ||
-        scope_values.includes(state.scope),
-      (ctx) => {
-        const input = ctx.input as { scope?: string };
-        const received = input.scope ? `"${input.scope}"` : "(empty)";
-        return `Invalid --scope ${received}. Valid scopes: ${format_allowed_values(scope_values)}${config.commit_scope.custom_scope ? ", or any custom scope value" : ""}.`;
-      },
-    ),
-    v.custom(
-      (state) => !!state.title?.trim(),
-      "Missing --title. Provide a non-empty commit title.",
-    ),
-    v.custom(
-      (state) =>
-        get_commit_title_size(state, {
-          include_ticket: config.check_ticket.add_to_title,
-        }) <= config.commit_title.max_size,
-      (ctx) => {
-        const input = ctx.input as {
-          type?: string;
-          scope?: string;
-          ticket?: string;
-          title?: string;
-        };
-        const size = get_commit_title_size(input, {
-          include_ticket: config.check_ticket.add_to_title,
+  return v.pipe(
+    v.object(COMMIT_STATE_ENTRIES),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (!dataset.typed) return;
+
+      const received = dataset.value.type ? `"${dataset.value.type}"` : "(empty)";
+      if (dataset.value.type && !type_values.includes(dataset.value.type)) {
+        addIssue({
+          message: `Invalid --type ${received}. Valid types: ${format_allowed_values(type_values)}.`,
         });
-        return `Title exceeds max width. Current size is ${size}, max is ${config.commit_title.max_size} (includes type, scope, and ticket when enabled).`;
-      },
-    ),
-    v.custom(
-      (state) => !config.commit_body.required || !!state.body?.trim(),
-      "Missing --body. commit_body.required is enabled in config.",
-    ),
-    v.custom(
-      (state) => !state.closes || !!state.ticket,
-      'Invalid footer values: --closes requires --ticket (for example: --ticket "ABC-123").',
-    ),
-    v.custom(
-      (state) => !state.breaking_body || !!state.breaking_title,
-      "Invalid breaking change values: --breaking-body requires --breaking-title.",
-    ),
-    v.custom(
-      (state) => !state.deprecates_body || !!state.deprecates_title,
-      "Invalid deprecation values: --deprecates-body requires --deprecates-title.",
-    ),
-  ]);
+      }
+    }),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (!dataset.typed) return;
+
+      const received = dataset.value.scope
+        ? `"${dataset.value.scope}"`
+        : "(empty)";
+
+      if (
+        dataset.value.scope &&
+        !config.commit_scope.custom_scope &&
+        !scope_values.includes(dataset.value.scope)
+      ) {
+        addIssue({
+          message: `Invalid --scope ${received}. Valid scopes: ${format_allowed_values(scope_values)}.`,
+        });
+      }
+    }),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (!dataset.typed || dataset.value.title.trim()) return;
+
+      addIssue({
+        message: "Missing --title. Provide a non-empty commit title.",
+      });
+    }),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (!dataset.typed) return;
+
+      const size = get_commit_title_size(dataset.value, {
+        include_ticket: config.check_ticket.add_to_title,
+      });
+
+      if (size > config.commit_title.max_size) {
+        addIssue({
+          message: `Title exceeds max width. Current size is ${size}, max is ${config.commit_title.max_size} (includes type, scope, and ticket when enabled).`,
+        });
+      }
+    }),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (
+        dataset.typed &&
+        config.commit_body.required &&
+        !dataset.value.body.trim()
+      ) {
+        addIssue({
+          message: "Missing --body. commit_body.required is enabled in config.",
+        });
+      }
+    }),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (dataset.typed && dataset.value.closes && !dataset.value.ticket) {
+        addIssue({
+          message:
+            'Invalid footer values: --closes requires --ticket (for example: --ticket "ABC-123").',
+        });
+      }
+    }),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (
+        dataset.typed &&
+        dataset.value.breaking_body &&
+        !dataset.value.breaking_title
+      ) {
+        addIssue({
+          message:
+            "Invalid breaking change values: --breaking-body requires --breaking-title.",
+        });
+      }
+    }),
+    v.rawCheck(({ dataset, addIssue }) => {
+      if (
+        dataset.typed &&
+        dataset.value.deprecates_body &&
+        !dataset.value.deprecates_title
+      ) {
+        addIssue({
+          message:
+            "Invalid deprecation values: --deprecates-body requires --deprecates-title.",
+        });
+      }
+    }),
+  );
 }

--- a/src/utils/no-interactive-validation.ts
+++ b/src/utils/no-interactive-validation.ts
@@ -182,7 +182,7 @@ export function create_strict_branch_state(
       ) {
         addIssue({
           message:
-            "Missing --version. branch_version.required is enabled in config.",
+            "Missing --branch-version. branch_version.required is enabled in config.",
         });
       }
     }),

--- a/src/utils/no-interactive-validation.ts
+++ b/src/utils/no-interactive-validation.ts
@@ -1,0 +1,79 @@
+import * as v from "valibot";
+import { COMMIT_STATE_ENTRIES, Config } from "../valibot-state";
+import { get_commit_title_size } from "./commit-title-size";
+
+function format_allowed_values(values: string[]): string {
+  const printable_values = values.map((value) =>
+    value === "" ? '"" (none)' : `"${value}"`,
+  );
+  return printable_values.join(", ");
+}
+
+export function create_strict_commit_state(
+  config: v.Output<typeof Config>,
+): v.ObjectSchema<typeof COMMIT_STATE_ENTRIES, undefined> {
+  const type_values = config.commit_type.options.map((option) => option.value);
+  const scope_values = config.commit_scope.options.map(
+    (option) => option.value,
+  );
+
+  return v.object(COMMIT_STATE_ENTRIES, [
+    v.custom(
+      (state) => !state.type || type_values.includes(state.type),
+      (ctx) => {
+        const input = ctx.input as { type?: string };
+        const received = input.type ? `"${input.type}"` : "(empty)";
+        return `Invalid --type ${received}. Valid types: ${format_allowed_values(type_values)}.`;
+      },
+    ),
+    v.custom(
+      (state) =>
+        !state.scope ||
+        config.commit_scope.custom_scope ||
+        scope_values.includes(state.scope),
+      (ctx) => {
+        const input = ctx.input as { scope?: string };
+        const received = input.scope ? `"${input.scope}"` : "(empty)";
+        return `Invalid --scope ${received}. Valid scopes: ${format_allowed_values(scope_values)}${config.commit_scope.custom_scope ? ", or any custom scope value" : ""}.`;
+      },
+    ),
+    v.custom(
+      (state) => !!state.title?.trim(),
+      "Missing --title. Provide a non-empty commit title.",
+    ),
+    v.custom(
+      (state) =>
+        get_commit_title_size(state, {
+          include_ticket: config.check_ticket.add_to_title,
+        }) <= config.commit_title.max_size,
+      (ctx) => {
+        const input = ctx.input as {
+          type?: string;
+          scope?: string;
+          ticket?: string;
+          title?: string;
+        };
+        const size = get_commit_title_size(input, {
+          include_ticket: config.check_ticket.add_to_title,
+        });
+        return `Title exceeds max width. Current size is ${size}, max is ${config.commit_title.max_size} (includes type, scope, and ticket when enabled).`;
+      },
+    ),
+    v.custom(
+      (state) => !config.commit_body.required || !!state.body?.trim(),
+      "Missing --body. commit_body.required is enabled in config.",
+    ),
+    v.custom(
+      (state) => !state.closes || !!state.ticket,
+      'Invalid footer values: --closes requires --ticket (for example: --ticket "ABC-123").',
+    ),
+    v.custom(
+      (state) => !state.breaking_body || !!state.breaking_title,
+      "Invalid breaking change values: --breaking-body requires --breaking-title.",
+    ),
+    v.custom(
+      (state) => !state.deprecates_body || !!state.deprecates_title,
+      "Invalid deprecation values: --deprecates-body requires --deprecates-title.",
+    ),
+  ]);
+}

--- a/src/valibot-consts.ts
+++ b/src/valibot-consts.ts
@@ -1,7 +1,7 @@
 import * as v from "valibot";
 
 export const CUSTOM_SCOPE_KEY: "custom" = "custom";
-export const FOOTER_OPTION_VALUES: v.Output<typeof V_FOOTER_OPTIONS>[] = [
+export const FOOTER_OPTION_VALUES: v.InferOutput<typeof V_FOOTER_OPTIONS>[] = [
   "closes",
   "trailer",
   "breaking-change",
@@ -30,7 +30,7 @@ export const V_BRANCH_CONFIG_FIELDS = v.picklist([
   "branch_ticket",
   "branch_description",
 ]);
-export const BRANCH_ORDER_DEFAULTS: v.Output<typeof V_BRANCH_FIELDS>[] = [
+export const BRANCH_ORDER_DEFAULTS: v.InferOutput<typeof V_BRANCH_FIELDS>[] = [
   "user",
   "version",
   "type",

--- a/src/valibot-state.test.ts
+++ b/src/valibot-state.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { ValiError, parse } from "valibot";
+import { Config } from "./valibot-state";
+
+describe("Config", () => {
+  it("parses a defaulted config from empty input", () => {
+    const config = parse(Config, {});
+
+    expect(config.commit_type.initial_value).toBe("feat");
+    expect(config.commit_scope.initial_value).toBe("app");
+    expect(config.commit_type.options.length).toBeGreaterThan(0);
+    expect(config.commit_scope.options.length).toBeGreaterThan(0);
+  });
+
+  it("adds the custom scope option when custom_scope is enabled", () => {
+    const config = parse(Config, {
+      commit_scope: {
+        custom_scope: true,
+        initial_value: "custom",
+        options: [{ value: "app", label: "app" }],
+      },
+    });
+
+    expect(config.commit_scope.options.map((option) => option.value)).toContain(
+      "custom",
+    );
+  });
+
+  it("rejects commit_type.initial_value values outside options", () => {
+    expect(() =>
+      parse(Config, {
+        commit_type: {
+          initial_value: "unknown",
+          options: [{ value: "feat", label: "feat" }],
+        },
+      }),
+    ).toThrowError(ValiError);
+
+    expect(() =>
+      parse(Config, {
+        commit_type: {
+          initial_value: "unknown",
+          options: [{ value: "feat", label: "feat" }],
+        },
+      }),
+    ).toThrow(/must exist in options/);
+  });
+});

--- a/src/valibot-state.ts
+++ b/src/valibot-state.ts
@@ -257,6 +257,7 @@ export const BranchState = v.optional(
     ticket: v.optional(v.string(), ""),
     description: v.optional(v.string(), ""),
     version: v.optional(v.string(), ""),
+    checkout_type: v.optional(V_BRANCH_ACTIONS, "branch"),
   }),
   {},
 );

--- a/src/valibot-state.ts
+++ b/src/valibot-state.ts
@@ -231,24 +231,23 @@ export const Config = v.object({
   ),
 });
 
-export const CommitState = v.optional(
-  v.object({
-    type: v.optional(v.string(), ""),
-    scope: v.optional(v.string(), ""),
-    title: v.optional(v.string(), ""),
-    body: v.optional(v.string(), ""),
-    closes: v.optional(v.string(), ""),
-    ticket: v.optional(v.string(), ""),
-    breaking_title: v.optional(v.string(), ""),
-    breaking_body: v.optional(v.string(), ""),
-    deprecates: v.optional(v.string(), ""),
-    deprecates_title: v.optional(v.string(), ""),
-    deprecates_body: v.optional(v.string(), ""),
-    custom_footer: v.optional(v.string(), ""),
-    trailer: v.optional(v.string(), ""),
-  }),
-  {},
-);
+export const COMMIT_STATE_ENTRIES = {
+  type: v.optional(v.string(), ""),
+  scope: v.optional(v.string(), ""),
+  title: v.optional(v.string(), ""),
+  body: v.optional(v.string(), ""),
+  closes: v.optional(v.string(), ""),
+  ticket: v.optional(v.string(), ""),
+  breaking_title: v.optional(v.string(), ""),
+  breaking_body: v.optional(v.string(), ""),
+  deprecates: v.optional(v.string(), ""),
+  deprecates_title: v.optional(v.string(), ""),
+  deprecates_body: v.optional(v.string(), ""),
+  custom_footer: v.optional(v.string(), ""),
+  trailer: v.optional(v.string(), ""),
+};
+
+export const CommitState = v.optional(v.object(COMMIT_STATE_ENTRIES), {});
 
 export const BranchState = v.optional(
   v.object({

--- a/src/valibot-state.ts
+++ b/src/valibot-state.ts
@@ -250,14 +250,16 @@ export const COMMIT_STATE_ENTRIES = {
 
 export const CommitState = v.optional(v.object(COMMIT_STATE_ENTRIES), {});
 
+export const BRANCH_STATE_ENTRIES = {
+  user: v.optional(v.string(), ""),
+  type: v.optional(v.string(), ""),
+  ticket: v.optional(v.string(), ""),
+  description: v.optional(v.string(), ""),
+  version: v.optional(v.string(), ""),
+  checkout: v.optional(V_BRANCH_ACTIONS, "branch"),
+};
+
 export const BranchState = v.optional(
-  v.object({
-    user: v.optional(v.string(), ""),
-    type: v.optional(v.string(), ""),
-    ticket: v.optional(v.string(), ""),
-    description: v.optional(v.string(), ""),
-    version: v.optional(v.string(), ""),
-    checkout_type: v.optional(V_BRANCH_ACTIONS, "branch"),
-  }),
+  v.object(BRANCH_STATE_ENTRIES),
   {},
 );

--- a/src/valibot-state.ts
+++ b/src/valibot-state.ts
@@ -10,113 +10,114 @@ import {
   V_FOOTER_OPTIONS,
 } from "./valibot-consts";
 
+const CommitTypeConfig = v.pipe(
+  v.optional(
+    v.object({
+      enable: v.optional(v.boolean(), true),
+      initial_value: v.optional(v.string(), "feat"),
+      max_items: v.optional(v.pipe(v.number(), v.minValue(1)), 20),
+      infer_type_from_branch: v.optional(v.boolean(), true),
+      append_emoji_to_label: v.optional(v.boolean(), false),
+      append_emoji_to_commit: v.optional(v.boolean(), false),
+      emoji_commit_position: v.optional(
+        v.picklist(["Start", "After-Colon"]),
+        "Start",
+      ),
+      options: v.optional(
+        v.array(
+          v.object({
+            value: v.string(),
+            label: v.optional(v.string()),
+            hint: v.optional(v.string()),
+            emoji: v.optional(v.pipe(v.string(), v.emoji())),
+            trailer: v.optional(v.string()),
+          }),
+        ),
+        DEFAULT_TYPE_OPTIONS,
+      ),
+    }),
+    {},
+  ),
+  v.rawCheck(({ dataset, addIssue }) => {
+    if (
+      dataset.typed &&
+      !dataset.value.options.some(
+        (option) => option.value === dataset.value.initial_value,
+      )
+    ) {
+      addIssue({
+        message: `Type: initial_value "${dataset.value.initial_value}" must exist in options`,
+      });
+    }
+  }),
+  v.transform((value) => ({
+    ...value,
+    options: value.options.map((option) => ({
+      ...option,
+      label:
+        option.emoji && value.append_emoji_to_label
+          ? `${option.emoji} ${option.label}`
+          : option.label,
+    })),
+  })),
+);
+
+const CommitScopeConfig = v.pipe(
+  v.optional(
+    v.object({
+      enable: v.optional(v.boolean(), true),
+      custom_scope: v.optional(v.boolean(), false),
+      max_items: v.optional(v.pipe(v.number(), v.minValue(1)), 20),
+      initial_value: v.optional(v.string(), "app"),
+      options: v.optional(
+        v.array(
+          v.object({
+            value: v.string(),
+            label: v.optional(v.string()),
+            hint: v.optional(v.string()),
+          }),
+        ),
+        DEFAULT_SCOPE_OPTIONS,
+      ),
+    }),
+    {},
+  ),
+  v.rawCheck(({ dataset, addIssue }) => {
+    if (!dataset.typed) return;
+
+    const option_values = dataset.value.options.map((option) => option.value);
+    if (dataset.value.custom_scope) option_values.push(CUSTOM_SCOPE_KEY);
+
+    if (!option_values.includes(dataset.value.initial_value)) {
+      addIssue({
+        message: `Scope: initial_value "${dataset.value.initial_value}" must exist in options`,
+      });
+    }
+  }),
+  v.transform((value) => {
+    const option_values = value.options.map((option) => option.value);
+    if (value.custom_scope && !option_values.includes(CUSTOM_SCOPE_KEY)) {
+      return {
+        ...value,
+        options: [
+          ...value.options,
+          {
+            label: CUSTOM_SCOPE_KEY,
+            value: CUSTOM_SCOPE_KEY,
+            hint: "Write a custom scope",
+          },
+        ],
+      };
+    }
+
+    return value;
+  }),
+);
+
 export const Config = v.object({
   check_status: v.optional(v.boolean(), true),
-  commit_type: v.transform(
-    v.optional(
-      v.object(
-        {
-          enable: v.optional(v.boolean(), true),
-          initial_value: v.optional(v.string(), "feat"),
-          max_items: v.optional(v.number([v.minValue(1)]), 20),
-          infer_type_from_branch: v.optional(v.boolean(), true),
-          append_emoji_to_label: v.optional(v.boolean(), false),
-          append_emoji_to_commit: v.optional(v.boolean(), false),
-          emoji_commit_position: v.optional(
-            v.picklist(["Start", "After-Colon"]),
-            "Start",
-          ),
-          options: v.optional(
-            v.array(
-              v.object({
-                value: v.string(),
-                label: v.optional(v.string()),
-                hint: v.optional(v.string()),
-                emoji: v.optional(v.string([v.emoji()]), undefined),
-                trailer: v.optional(v.string()),
-              }),
-            ),
-            DEFAULT_TYPE_OPTIONS,
-          ),
-        },
-        [
-          v.custom(
-            (val) =>
-              val.options.map((v) => v.value).includes(val.initial_value),
-            (val) => {
-              const input = val.input as { initial_value: string };
-              return `Type: initial_value "${input.initial_value}" must exist in options`;
-            },
-          ),
-        ],
-      ),
-      {},
-    ),
-    (val) => {
-      const options =
-        val.options.map((v) => ({
-          ...v,
-          label:
-            v.emoji && val.append_emoji_to_label
-              ? `${v.emoji} ${v.label}`
-              : v.label,
-        })) ?? [];
-      return { ...val, options };
-    },
-  ),
-  commit_scope: v.transform(
-    v.optional(
-      v.object(
-        {
-          enable: v.optional(v.boolean(), true),
-          custom_scope: v.optional(v.boolean(), false),
-          max_items: v.optional(v.number([v.minValue(1)]), 20),
-          initial_value: v.optional(v.string(), "app"),
-          options: v.optional(
-            v.array(
-              v.object({
-                value: v.string(),
-                label: v.optional(v.string()),
-                hint: v.optional(v.string()),
-              }),
-            ),
-            DEFAULT_SCOPE_OPTIONS,
-          ),
-        },
-        [
-          v.custom(
-            (val) => {
-              const options = val.options.map((v) => v.value);
-              if (val.custom_scope) options.push(CUSTOM_SCOPE_KEY);
-              return options.includes(val.initial_value);
-            },
-            (val) => {
-              const input = val.input as { initial_value: string };
-              return `Scope: initial_value "${input.initial_value}" must exist in options`;
-            },
-          ),
-        ],
-      ),
-      {},
-    ),
-    (val) => {
-      const options = val.options.map((v) => v.value);
-      if (val.custom_scope && !options.includes(CUSTOM_SCOPE_KEY)) {
-        return {
-          ...val,
-          options: [
-            ...val.options,
-            {
-              label: CUSTOM_SCOPE_KEY,
-              value: CUSTOM_SCOPE_KEY,
-              hint: "Write a custom scope",
-            },
-          ],
-        };
-      }
-      return val;
-    },
-  ),
+  commit_type: CommitTypeConfig,
+  commit_scope: CommitScopeConfig,
   check_ticket: v.optional(
     v.object({
       infer_ticket: v.optional(v.boolean(), true),
@@ -137,7 +138,7 @@ export const Config = v.object({
   ),
   commit_title: v.optional(
     v.object({
-      max_size: v.optional(v.number([v.minValue(1)]), 70),
+      max_size: v.optional(v.pipe(v.number(), v.minValue(1)), 70),
     }),
     {},
   ),
@@ -204,7 +205,7 @@ export const Config = v.object({
   ),
   branch_description: v.optional(
     v.object({
-      max_length: v.optional(v.number([v.minValue(1)]), 70),
+      max_length: v.optional(v.pipe(v.number(), v.minValue(1)), 70),
       separator: v.optional(v.picklist(["", "/", "-", "_"]), ""),
     }),
     {},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,13 @@
     "module": "ESNext",
     "target": "ESNext",
     "declaration": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "emitDeclarationOnly": true,
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "allowJs": true,
     "types": ["node"]
-  }
+  },
+  "exclude": ["dist", "node_modules", ".svelte-kit", ".opencode"]
 }


### PR DESCRIPTION
Added ability to pass commit state via CLI arguments.
Added unit tests for building commits.
Added unit tests for building branch / worktrees.
Added Github Actions to run unit tests.
First draft of help command.
better-branch help command.
TODO: expose skills via help + help --json.
TODO: add scope as better-branch prompt + possible inference. (Maybe out of scope)