### PR TITLE
feat(init): use jsonc over json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@clack/core": "^1.2.0",
         "@clack/prompts": "^1.2.0",
         "configstore": "^5.0.1",
+        "jsonc-parser": "^3.3.1",
         "picocolors": "^1.0.0",
         "valibot": "^1.3.1"
       },
@@ -4140,6 +4141,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -13631,6 +13638,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
     },
     "jsonfile": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@clack/core": "^1.2.0",
     "@clack/prompts": "^1.2.0",
     "configstore": "^5.0.1",
+    "jsonc-parser": "^3.3.1",
     "picocolors": "^1.0.0",
     "valibot": "^1.3.1"
   },

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ better-branch # Create a new branch
 
 `better-commits` will prompt a series of questions. These prompts will build a commit message, which you can preview, before confirming the commit. - To better understand these prompts and their intention, read [Conventional Commits Summary](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
 
-Some of the values in these prompts will be inferred by your branch name and auto populated. You can adjust this in your `.better-commits.json` configuration file.
+Some of the values in these prompts will be inferred by your branch name and auto populated. You can adjust this in your `.better-commits.jsonc` (or `.better-commits.json`) configuration file.
 
 For documentation on passing commit values to `better-commits` via the CLI, see [CLI Flags](#cli-flags).
 
@@ -64,7 +64,7 @@ For documentation on passing commit values to `better-commits` via the CLI, see 
 
 ### Global
 
-Your first time running `better-commits`, a default config will be generated in your `$HOME` directory, named `.better-commits.json`
+Your first time running `better-commits`, a default config will be generated in your `$HOME` directory, named `.better-commits.jsonc` (formerly `.better-commits.json`)
 
 - This config will be used if a repository-specific config cannot be found.
 
@@ -73,7 +73,7 @@ Your first time running `better-commits`, a default config will be generated in 
 To create a **repository-specific config**, navigate to the root of your project.
 
 - Run `better-commits-init`
-- This will create a default config named `.better-commits.json`
+- This will create a default config named `.better-commits.jsonc`
 - Properties such as `confirm_with_editor` and `overrides` will prefer the global config
 
 ### 💫 Properties
@@ -389,7 +389,7 @@ better-branch --no-interactive --type feat --ticket TAC-123 --description "add p
 
 #### Multi-line
 
-If your are having issues with multilines for commits on windows, you can override the shell via your `.better-commits.json` config.
+If your are having issues with multilines for commits on windows, you can override the shell via your `.better-commits.jsonc` config.
 
 Example
 

--- a/readme.md
+++ b/readme.md
@@ -442,7 +442,7 @@ better-branch --no-interactive --type feat --ticket TAC-123 --description "add p
 
 #### Multi-line
 
-If your are having issues with multilines for commits on windows, you can override the shell via your `.better-commits.jsonc` config.
+If you are having issues with multilines for commits on windows, you can override the shell via your `.better-commits.jsonc` config.
 
 Example
 

--- a/readme.md
+++ b/readme.md
@@ -76,289 +76,205 @@ To create a **repository-specific config**, navigate to the root of your project
 - This will create a default config named `.better-commits.json`
 - Properties such as `confirm_with_editor` and `overrides` will prefer the global config
 
-### Options
+### 💫 Properties
 
 > [!NOTE]<br>
-> All properties are optional and can be removed from the config. It will be replaced by the default at run-time.
+> All properties are optional and can be removed from the config. They will be replaced by the default at run-time.
 >
 > - See `.better-commits.json` in this repository as an example
 
-### 💫 Default JSON Config
-
-<details open>
-<summary>Expand / Collapse</summary>
-
-```json
+```jsonc
 {
+  // Run interactive `git status` before composing a commit
   "check_status": true,
+
+  /* COMMIT FIELDS */
   "commit_type": {
     "enable": true,
+
+    // Default selected type from options
     "initial_value": "feat",
-    "max_items": 20,
+
+    // Infer type from the current branch name: user/TYPE/my-branch
     "infer_type_from_branch": true,
+
+    // Include emoji in prompt label
     "append_emoji_to_label": false,
+
+    // Include emoji from prompt label in commit message
     "append_emoji_to_commit": false,
+
+    // "Start" | "After-Colon"
     "emoji_commit_position": "Start",
+
     "options": [
       {
         "value": "feat",
         "label": "feat",
         "hint": "A new feature",
         "emoji": "🌟",
-        "trailer": "Changelog: feature"
+        "trailer": "Changelog: feature",
       },
       {
         "value": "fix",
         "label": "fix",
         "hint": "A bug fix",
         "emoji": "🐛",
-        "trailer": "Changelog: fix"
-      },
-      {
-        "value": "docs",
-        "label": "docs",
-        "hint": "Documentation only changes",
-        "emoji": "📚",
-        "trailer": "Changelog: documentation"
-      },
-      {
-        "value": "refactor",
-        "label": "refactor",
-        "hint": "A code change that neither fixes a bug nor adds a feature",
-        "emoji": "🔨",
-        "trailer": "Changelog: refactor"
-      },
-      {
-        "value": "perf",
-        "label": "perf",
-        "hint": "A code change that improves performance",
-        "emoji": "🚀",
-        "trailer": "Changelog: performance"
-      },
-      {
-        "value": "test",
-        "label": "test",
-        "hint": "Adding missing tests or correcting existing tests",
-        "emoji": "🚨",
-        "trailer": "Changelog: test"
-      },
-      {
-        "value": "build",
-        "label": "build",
-        "hint": "Changes that affect the build system or external dependencies",
-        "emoji": "🚧",
-        "trailer": "Changelog: build"
-      },
-      {
-        "value": "ci",
-        "label": "ci",
-        "hint": "Changes to our CI configuration files and scripts",
-        "emoji": "🤖",
-        "trailer": "Changelog: ci"
-      },
-      {
-        "value": "chore",
-        "label": "chore",
-        "hint": "Other changes that do not modify src or test files",
-        "emoji": "🧹",
-        "trailer": "Changelog: chore"
+        "trailer": "Changelog: fix",
       },
       {
         "value": "",
-        "label": "none"
-      }
-    ]
+        "label": "none",
+      },
+    ],
   },
+
   "commit_scope": {
     "enable": true,
+
+    // If true, users can type a scope not listed in options
     "custom_scope": false,
+
+    // Default selected scope from options
     "initial_value": "app",
+
     "max_items": 20,
     "options": [
-      {
-        "value": "app",
-        "label": "app"
-      },
-      {
-        "value": "shared",
-        "label": "shared"
-      },
-      {
-        "value": "server",
-        "label": "server"
-      },
-      {
-        "value": "tools",
-        "label": "tools"
-      },
-      {
-        "value": "",
-        "label": "none"
-      }
-    ]
+      { "value": "app", "label": "app" },
+      { "value": "shared", "label": "shared" },
+      { "value": "", "label": "none" },
+    ],
   },
+
   "check_ticket": {
+    // Infer ticket / issue from the branch name - user/type/TICKET-my-branch
     "infer_ticket": true,
+
+    // Prompt for confirmation / edit before using an inferred ticket
     "confirm_ticket": true,
+
+    // Add the ticket to the commit title - feat(app): TICKET my commit title
     "add_to_title": true,
+
+    // Deprecated, prefer `prepend_hashtag`
     "append_hashtag": false,
+
+    // "Never" | "Prompt" | "Always" - 12345 --> #12345
     "prepend_hashtag": "Never",
+
+    // Wrap the ticket in the commit title: "" | "[]" | "()" | "{}"
     "surround": "",
-    "title_position": "start"
+
+    // "start" | "end" | "before-colon" | "beginning"
+    "title_position": "start",
   },
+
   "commit_title": {
-    "max_size": 70
+    // Includes total size of title + type + scope + ticket
+    "max_size": 70,
   },
+
   "commit_body": {
     "enable": true,
     "required": false,
-    "split_by_period": false
+
+    // Split sentences into multiple lines automatically
+    "split_by_period": false,
   },
+
   "commit_footer": {
     "enable": true,
     "initial_value": [],
-    "options": ["closes", "trailer", "breaking-change", "deprecated", "custom"]
+
+    // "closes", "trailer", "breaking-change", "deprecated", "custom"
+    "options": ["closes", "trailer", "breaking-change", "deprecated", "custom"],
   },
+
   "breaking_change": {
-    "add_exclamation_to_title": true
+    // Adds `!` to the commit title when a breaking change is selected
+    "add_exclamation_to_title": true,
   },
-  "confirm_commit": true,
-  "cache_last_value": true,
+
+  // Confirm / edit with $GIT_EDITOR or $EDITOR
   "confirm_with_editor": false,
+
+  // Show a final confirmation prompt before running git commit
+  "confirm_commit": true,
+
+  // Reuse the last known value from a previous canceled or failed commit
+  "cache_last_value": true,
+
+  // Pretty-print the final commit preview before execution
   "print_commit_output": true,
+
+  /* BRANCH FIELDS */
+  // Optional shell commands to run before / after creating branches or worktrees
   "branch_pre_commands": [],
   "branch_post_commands": [],
   "worktree_pre_commands": [],
   "worktree_post_commands": [],
+
   "branch_user": {
     "enable": true,
     "required": false,
-    "separator": "/"
+
+    // "/" | "-" | "_" - user/feat/my-branch
+    "separator": "/",
   },
+
   "branch_type": {
     "enable": true,
-    "separator": "/"
+    "separator": "/",
   },
-  "branch_version": {
-    "enable": false,
-    "required": false,
-    "separator": "/"
-  },
+
   "branch_ticket": {
     "enable": true,
     "required": false,
-    "separator": "-"
+    "separator": "-",
   },
+
+  "branch_version": {
+    "enable": false,
+    "required": false,
+    "separator": "/",
+  },
+
   "branch_description": {
+    // Maximum length for the description segment of the branch name
     "max_length": 70,
-    "separator": ""
+
+    // Allowed values: "" | "/" | "-" | "_"
+    "separator": "",
   },
+
+  // "branch" | "worktree"
   "branch_action_default": "branch",
+
+  // Order of values in the final branch name
   "branch_order": ["user", "version", "type", "ticket", "description"],
+
+  // Deprecated, prefer `worktrees.enable`
+  "enable_worktrees": true,
+
   "worktrees": {
+    // If false, always create a branch instead of prompting for a worktree
     "enable": true,
+
+    // Directory where worktrees are created
     "base_path": "..",
-    "folder_template": "{{repo_name}}-{{ticket}}-{{branch_description}}"
+
+    // Available template variables include:
+    // {{repo_name}}, {{branch_description}}, {{user}}, {{type}}, {{ticket}}, {{version}}
+    "folder_template": "{{repo_name}}-{{ticket}}-{{branch_description}}",
   },
+
+  /* OTHER FIELDS */
   "overrides": {
-    "shell": "/bin/sh"
-  }
+    // Useful on Windows or for shells with different multiline behavior
+    "shell": "/bin/sh",
+  },
 }
 ```
-
-</details>
-
-> [!NOTE]<br>
-> Some properties allow a set of specific string values
->
-> - See _config file explanations_ for possible values
-
-### 🔭 Config File Explanations
-
-Expand to see explanations and possible values
-
-<details>
-<summary>Expand / Collapse</summary>
-
-`.` refers to nesting. i.e. if a property is `commit_type.enable` then expect in the config for it to be:
-
-```json
-"commit_type": {
-  "enable": true
-}
-```
-
-| Property                                   | Description                                                                                         |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------- |
-| `check_status`                             | If true run interactive `git status`                                                                |
-| `commit_type.enable`                       | If true include commit type                                                                         |
-| `commit_type.initial_value`                | Initial selection of commit type                                                                    |
-| `commit_type.max_items`                    | Maximum number of type displayed on the screen                                                      |
-| `commit_type.infer_type_from_branch`       | If true infer type from branch name                                                                 |
-| `commit_type.append_emoji_to_label`        | If true append emoji to prompt                                                                      |
-| `commit_type.append_emoji_to_commit`       | If true append emoji to commit                                                                      |
-| `commit_type.emoji_commit_position`        | Emoji position, "Start" (default) or "After-Colon"                                                  |
-| `commit_type.options.value`                | Commit type prompt value                                                                            |
-| `commit_type.options.label`                | Commit type prompt label                                                                            |
-| `commit_type.options.hint`                 | Commit type inline hint (like this)                                                                 |
-| `commit_type.options.emoji`                | Commit type emoji                                                                                   |
-| `commit_type.options.trailer`              | Commit type trailer                                                                                 |
-| `commit_scope.enable`                      | If true include commit scope                                                                        |
-| `commit_scope.custom_scope`                | If true allow custom scope at run-time                                                              |
-| `commit_scope.initial_value`               | Default commit scope selected                                                                       |
-| `commit_scope.max_items`                   | Maximum number of scope displayed on the screen                                                     |
-| `commit_scope.options.value`               | Commit scope value                                                                                  |
-| `commit_scope.options.label`               | Commit scope label                                                                                  |
-| `check_ticket.infer_ticket`                | If true infer ticket from branch name                                                               |
-| `check_ticket.confirm_ticket`              | If true manually confirm inference                                                                  |
-| `check_ticket.add_to_title`                | If true add ticket to title                                                                         |
-| `check_ticket.append_hashtag`              | **Deprecated**: see prepend_hashtag                                                                 |
-| `check_ticket.prepend_hashtag`             | "Never" (default), "Prompt", or "Always"                                                            |
-| `check_ticket.title_position`              | "start" (of description) (default), "end", "before-colon", "beginning" (of the entire commit title) |
-| `check_ticket.surround`                    | "" (default), "[]", "()", "{}" - Wraps ticket in title                                              |
-| `commit_title.max_size`                    | Max size of title including scope, type, etc...                                                     |
-| `commit_body.enable`                       | If true include body                                                                                |
-| `commit_body.required`                     | If true body is required                                                                            |
-| `commit_body.split_by_period`              | Automatically split sentences into new lines                                                        |
-| `commit_footer.enable`                     | If true include footer                                                                              |
-| `commit_footer.initial_value`              | Initial values selected in footer                                                                   |
-| `commit_footer.options`                    | Footer options                                                                                      |
-| `breaking_change.add_exclamation_to_title` | If true adds exclamation mark to title for breaking changes                                         |
-| `confirm_commit`                           | If true manually confirm commit at end                                                              |
-| `confirm_with_editor`                      | Confirm / Edit commit with $GIT_EDITOR / $EDITOR                                                    |
-| `cache_last_value`                         | Reuse last prompt value after cancel                                                                |
-| `print_commit_output`                      | If true pretty print commit preview                                                                 |
-| `overrides.shell`                          | Override default shell, useful for windows users                                                    |
-
-Branch configuration (same config file, split for readability)
-
-| Property                        | Description                                                                                                                               |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `branch_pre_commands`           | Array of shell commands to run before branching                                                                                           |
-| `branch_post_commands`          | Array of shell commands to run after branching                                                                                            |
-| `worktree_pre_commands`         | Array of shell commands to run before creating worktree                                                                                   |
-| `worktree_post_commands`        | Array of shell commands to run after creating worktree                                                                                    |
-| `branch_user.enable`            | If enabled include user name                                                                                                              |
-| `branch_user.required`          | If enabled require user name                                                                                                              |
-| `branch_user.separator`         | Branch delimeter - "/" (default), "-", "\_"                                                                                               |
-| `branch_type.enable`            | If enabled include type                                                                                                                   |
-| `branch_type.separator`         | Branch delimeter - "/" (default), "-", "\_"                                                                                               |
-| `branch_ticket.enable`          | If enabled include ticket                                                                                                                 |
-| `branch_ticket.required`        | If enabled require ticket                                                                                                                 |
-| `branch_ticket.separator`       | Branch delimeter - "/", "-" (default), "\_"                                                                                               |
-| `branch_description.max_length` | Max length branch name                                                                                                                    |
-| `branch_description.separator`  | Branch delimeter - "" (default), "/", "-", "\_"                                                                                           |
-| `branch_version.enable`         | If enabled include version                                                                                                                |
-| `branch_version.required`       | If enabled require version                                                                                                                |
-| `branch_version.separator`      | Branch delimeter - "", "/" (default), "-", "\_"                                                                                           |
-| `branch_order`                  | Order of branch name values (doesn't affect prompt order)                                                                                 |
-| `branch_action_default`         | "branch" or "worktree"                                                                                                                    |
-| `enable_worktrees`              | `Deprecated` see `worktrees.enable`                                                                                                       |
-| `worktrees.enable`              | If false, always default to branch action                                                                                                 |
-| `worktrees.base_path`           | Directory where worktrees are created (default: "..")                                                                                     |
-| `worktrees.folder_template`     | Template for worktree folder names with variables like {{repo_name}}, {{branch_description}}, {{user}}, {{type}}, {{ticket}}, {{version}} |
-
-</details>
 
 ### 🔎 Inference
 

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,8 @@ To create a **repository-specific config**, navigate to the root of your project
     // Default selected type from options
     "initial_value": "feat",
 
+    "max_items": 20,
+
     // Infer type from the current branch name: user/TYPE/my-branch
     "infer_type_from_branch": true,
 
@@ -123,6 +125,55 @@ To create a **repository-specific config**, navigate to the root of your project
         "trailer": "Changelog: fix",
       },
       {
+        "value": "docs",
+        "label": "docs",
+        "hint": "Documentation only changes",
+        "emoji": "📚",
+        "trailer": "Changelog: documentation",
+      },
+      {
+        "value": "refactor",
+        "label": "refactor",
+        "hint": "A code change that neither fixes a bug nor adds a feature",
+        "emoji": "🔨",
+        "trailer": "Changelog: refactor",
+      },
+      {
+        "value": "perf",
+        "label": "perf",
+        "hint": "A code change that improves performance",
+        "emoji": "🚀",
+        "trailer": "Changelog: performance",
+      },
+      {
+        "value": "test",
+        "label": "test",
+        "hint": "Adding missing tests or correcting existing tests",
+        "emoji": "🚨",
+        "trailer": "Changelog: test",
+      },
+      {
+        "value": "build",
+        "label": "build",
+        "hint": "Changes that affect the build system or external dependencies",
+        "emoji": "🚧",
+        "trailer": "Changelog: build",
+      },
+      {
+        "value": "ci",
+        "label": "ci",
+        "hint": "Changes to our CI configuration files and scripts",
+        "emoji": "🤖",
+        "trailer": "Changelog: ci",
+      },
+      {
+        "value": "chore",
+        "label": "chore",
+        "hint": "Other changes that do not modify src or test files",
+        "emoji": "🧹",
+        "trailer": "Changelog: chore",
+      },
+      {
         "value": "",
         "label": "none",
       },
@@ -142,6 +193,8 @@ To create a **repository-specific config**, navigate to the root of your project
     "options": [
       { "value": "app", "label": "app" },
       { "value": "shared", "label": "shared" },
+      { "value": "server", "label": "server" },
+      { "value": "tools", "label": "tools" },
       { "value": "", "label": "none" },
     ],
   },

--- a/src/default-config-template.ts
+++ b/src/default-config-template.ts
@@ -1,0 +1,242 @@
+export const DEFAULT_CONFIG_TEMPLATE = `{
+  // Run interactive \`git status\` before composing a commit
+  "check_status": true,
+
+  /* COMMIT FIELDS */
+  "commit_type": {
+    "enable": true,
+
+    // Default selected type from options
+    "initial_value": "feat",
+
+    // Infer type from the current branch name: user/TYPE/my-branch
+    "infer_type_from_branch": true,
+
+    // Include emoji in prompt label
+    "append_emoji_to_label": false,
+
+    // Include emoji from prompt label in commit message
+    "append_emoji_to_commit": false,
+
+    // "Start" | "After-Colon"
+    "emoji_commit_position": "Start",
+
+    "options": [
+      {
+        "value": "feat",
+        "label": "feat",
+        "hint": "A new feature",
+        "emoji": "🌟",
+        "trailer": "Changelog: feature"
+      },
+      {
+        "value": "fix",
+        "label": "fix",
+        "hint": "A bug fix",
+        "emoji": "🐛",
+        "trailer": "Changelog: fix"
+      },
+      {
+        "value": "docs",
+        "label": "docs",
+        "hint": "Documentation only changes",
+        "emoji": "📚",
+        "trailer": "Changelog: documentation"
+      },
+      {
+        "value": "refactor",
+        "label": "refactor",
+        "hint": "A code change that neither fixes a bug nor adds a feature",
+        "emoji": "🔨",
+        "trailer": "Changelog: refactor"
+      },
+      {
+        "value": "perf",
+        "label": "perf",
+        "hint": "A code change that improves performance",
+        "emoji": "🚀",
+        "trailer": "Changelog: performance"
+      },
+      {
+        "value": "test",
+        "label": "test",
+        "hint": "Adding missing tests or correcting existing tests",
+        "emoji": "🚨",
+        "trailer": "Changelog: test"
+      },
+      {
+        "value": "build",
+        "label": "build",
+        "hint": "Changes that affect the build system or external dependencies",
+        "emoji": "🚧",
+        "trailer": "Changelog: build"
+      },
+      {
+        "value": "ci",
+        "label": "ci",
+        "hint": "Changes to our CI configuration files and scripts",
+        "emoji": "🤖",
+        "trailer": "Changelog: ci"
+      },
+      {
+        "value": "chore",
+        "label": "chore",
+        "hint": "Other changes that do not modify src or test files",
+        "emoji": "🧹",
+        "trailer": "Changelog: chore"
+      },
+      {
+        "value": "",
+        "label": "none"
+      }
+    ]
+  },
+
+  "commit_scope": {
+    "enable": true,
+
+    // If true, users can type a scope not listed in options
+    "custom_scope": false,
+
+    // Default selected scope from options
+    "initial_value": "app",
+
+    "max_items": 20,
+    "options": [
+      { "value": "app", "label": "app" },
+      { "value": "shared", "label": "shared" },
+      { "value": "server", "label": "server" },
+      { "value": "tools", "label": "tools" },
+      { "value": "", "label": "none" }
+    ]
+  },
+
+  "check_ticket": {
+    // Infer ticket / issue from the branch name - user/type/TICKET-my-branch
+    "infer_ticket": true,
+
+    // Prompt for confirmation / edit before using an inferred ticket
+    "confirm_ticket": true,
+
+    // Add the ticket to the commit title - feat(app): TICKET my commit title
+    "add_to_title": true,
+
+    // Deprecated, prefer \`prepend_hashtag\`
+    "append_hashtag": false,
+
+    // "Never" | "Prompt" | "Always" - 12345 --> #12345
+    "prepend_hashtag": "Never",
+
+    // Wrap the ticket in the commit title: "" | "[]" | "()" | "{}"
+    "surround": "",
+
+    // "start" | "end" | "before-colon" | "beginning"
+    "title_position": "start"
+  },
+
+  "commit_title": {
+    // Includes total size of title + type + scope + ticket
+    "max_size": 70
+  },
+
+  "commit_body": {
+    "enable": true,
+    "required": false,
+
+    // Split sentences into multiple lines automatically
+    "split_by_period": false
+  },
+
+  "commit_footer": {
+    "enable": true,
+    "initial_value": [],
+
+    // "closes", "trailer", "breaking-change", "deprecated", "custom"
+    "options": ["closes", "trailer", "breaking-change", "deprecated", "custom"]
+  },
+
+  "breaking_change": {
+    // Adds \`!\` to the commit title when a breaking change is selected
+    "add_exclamation_to_title": true
+  },
+
+  // Confirm / edit with $GIT_EDITOR or $EDITOR
+  "confirm_with_editor": false,
+
+  // Show a final confirmation prompt before running git commit
+  "confirm_commit": true,
+
+  // Reuse the last known value from a previous canceled or failed commit
+  "cache_last_value": true,
+
+  // Pretty-print the final commit preview before execution
+  "print_commit_output": true,
+
+  /* BRANCH FIELDS */
+  // Optional shell commands to run before / after creating branches or worktrees
+  "branch_pre_commands": [],
+  "branch_post_commands": [],
+  "worktree_pre_commands": [],
+  "worktree_post_commands": [],
+
+  "branch_user": {
+    "enable": true,
+    "required": false,
+
+    // "/" | "-" | "_" - user/feat/my-branch
+    "separator": "/"
+  },
+
+  "branch_type": {
+    "enable": true,
+    "separator": "/"
+  },
+
+  "branch_ticket": {
+    "enable": true,
+    "required": false,
+    "separator": "-"
+  },
+
+  "branch_version": {
+    "enable": false,
+    "required": false,
+    "separator": "/"
+  },
+
+  "branch_description": {
+    // Maximum length for the description segment of the branch name
+    "max_length": 70,
+
+    // Allowed values: "" | "/" | "-" | "_"
+    "separator": ""
+  },
+
+  // "branch" | "worktree"
+  "branch_action_default": "branch",
+
+  // Order of values in the final branch name
+  "branch_order": ["user", "version", "type", "ticket", "description"],
+
+  // Deprecated, prefer \`worktrees.enable\`
+  "enable_worktrees": true,
+
+  "worktrees": {
+    // If false, always create a branch instead of prompting for a worktree
+    "enable": true,
+
+    // Directory where worktrees are created
+    "base_path": "..",
+
+    // Available template variables include:
+    // {{repo_name}}, {{branch_description}}, {{user}}, {{type}}, {{ticket}}, {{version}}
+    "folder_template": "{{repo_name}}-{{ticket}}-{{branch_description}}"
+  },
+
+  /* OTHER FIELDS */
+  "overrides": {
+    // Useful on Windows or for shells with different multiline behavior
+    "shell": "/bin/sh"
+  }
+}
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,9 +78,9 @@ export async function main(
       parse(create_strict_commit_state(config), commit_state);
     } catch (err) {
       if (err instanceof ValiError) {
-        p.log.error(`Invalid --no-interactive commit input: ${err.message}`);
+        p.log.error(`Invalid commit input: ${err.message}`);
       } else {
-        p.log.error(`Failed to validate --no-interactive commit input: ${err}`);
+        p.log.error(`Failed to validate commit input: ${err}`);
       }
       process.exit(0);
     }

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -1,0 +1,105 @@
+import fs from "fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({
+  writeFileSync: vi.fn<typeof fs.writeFileSync>(),
+  intro: vi.fn(),
+  outro: vi.fn(),
+  confirm: vi.fn(),
+  isCancel: vi.fn(() => false),
+  success: vi.fn(),
+  error: vi.fn(),
+  get_git_root: vi.fn(() => "/repo"),
+  get_repository_config_path: vi.fn<() => string | null>(),
+}));
+
+vi.mock("fs", () => ({
+  default: {
+    writeFileSync: mocked.writeFileSync,
+  },
+}));
+
+vi.mock("@clack/prompts", () => ({
+  intro: mocked.intro,
+  outro: mocked.outro,
+  confirm: mocked.confirm,
+  isCancel: mocked.isCancel,
+  log: {
+    success: mocked.success,
+    error: mocked.error,
+  },
+}));
+
+vi.mock("./utils", async () => {
+  const actual = await vi.importActual<typeof import("./utils")>("./utils");
+  return {
+    ...actual,
+    get_git_root: mocked.get_git_root,
+    get_repository_config_path: mocked.get_repository_config_path,
+  };
+});
+
+describe("create_init_config", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocked.writeFileSync.mockReset();
+    mocked.intro.mockReset();
+    mocked.outro.mockReset();
+    mocked.confirm.mockReset();
+    mocked.isCancel.mockReset();
+    mocked.isCancel.mockReturnValue(false);
+    mocked.success.mockReset();
+    mocked.error.mockReset();
+    mocked.get_git_root.mockReset();
+    mocked.get_git_root.mockReturnValue("/repo");
+    mocked.get_repository_config_path.mockReset();
+  });
+
+  it("creates a new config when none exists", async () => {
+    mocked.get_repository_config_path.mockReturnValue(null);
+
+    const { create_init_config } = await import("./init");
+    mocked.writeFileSync.mockClear();
+    mocked.confirm.mockClear();
+    mocked.outro.mockClear();
+
+    await create_init_config();
+
+    expect(mocked.confirm).not.toHaveBeenCalled();
+    expect(mocked.writeFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks before overwriting an existing config", async () => {
+    mocked.get_repository_config_path.mockReturnValue("/repo/.better-commits.jsonc");
+    mocked.confirm.mockResolvedValue(true);
+
+    const { create_init_config } = await import("./init");
+    mocked.writeFileSync.mockClear();
+    mocked.confirm.mockClear();
+    mocked.outro.mockClear();
+
+    await create_init_config();
+
+    expect(mocked.confirm).toHaveBeenCalledTimes(1);
+    expect(mocked.writeFileSync).toHaveBeenCalledWith(
+      "/repo/.better-commits.jsonc",
+      expect.any(String),
+    );
+  });
+
+  it("does not overwrite when confirmation is declined", async () => {
+    mocked.get_repository_config_path.mockReturnValue("/repo/.better-commits.jsonc");
+    mocked.confirm.mockResolvedValue(false);
+
+    const { create_init_config } = await import("./init");
+    mocked.writeFileSync.mockClear();
+    mocked.confirm.mockClear();
+    mocked.outro.mockClear();
+
+    await create_init_config();
+
+    expect(mocked.confirm).toHaveBeenCalledTimes(1);
+    expect(mocked.writeFileSync).not.toHaveBeenCalled();
+    expect(mocked.outro).toHaveBeenCalledWith("Cancelled");
+  });
+});

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -87,6 +87,24 @@ describe("create_init_config", () => {
     );
   });
 
+  it("writes the canonical jsonc file when a legacy json config exists", async () => {
+    mocked.get_repository_config_path.mockReturnValue("/repo/.better-commits.json");
+    mocked.confirm.mockResolvedValue(true);
+
+    const { create_init_config } = await import("./init");
+    mocked.writeFileSync.mockClear();
+    mocked.confirm.mockClear();
+    mocked.outro.mockClear();
+
+    await create_init_config();
+
+    expect(mocked.confirm).toHaveBeenCalledTimes(1);
+    expect(mocked.writeFileSync).toHaveBeenCalledWith(
+      "/repo/.better-commits.jsonc",
+      expect.any(String),
+    );
+  });
+
   it("does not overwrite when confirmation is declined", async () => {
     mocked.get_repository_config_path.mockReturnValue("/repo/.better-commits.jsonc");
     mocked.confirm.mockResolvedValue(false);

--- a/src/init.ts
+++ b/src/init.ts
@@ -23,11 +23,11 @@ export async function create_init_config() {
   p.intro(`${color.bgCyan(color.black(" better-commits-init "))}`);
   const root = get_git_root();
   const existing_config_path = get_repository_config_path(root);
-  const root_path = existing_config_path ?? `${root}/${CONFIG_FILE_NAME}`;
+  const root_path = `${root}/${CONFIG_FILE_NAME}`;
 
   if (existing_config_path) {
     const should_overwrite = (await p.confirm({
-      message: `${root_path.split("/").pop()} already exists. Replace with default .better-commits.jsonc?`,
+      message: `${existing_config_path.split("/").pop()} already exists. Replace with default ${CONFIG_FILE_NAME}?`,
     })) as boolean;
 
     if (p.isCancel(should_overwrite) || !should_overwrite) {

--- a/src/init.ts
+++ b/src/init.ts
@@ -10,13 +10,7 @@ import {
   get_repository_config_path,
 } from "./utils";
 
-try {
-  await create_init_config();
-} catch {
-  p.log.error(
-    `${color.red("Could not determine git root folder. better-commits-init must be used in a git repository")}`,
-  );
-}
+await create_init_config();
 
 export async function create_init_config() {
   console.clear();
@@ -36,7 +30,13 @@ export async function create_init_config() {
     }
   }
 
-  fs.writeFileSync(root_path, DEFAULT_CONFIG_TEMPLATE);
+  try {
+    fs.writeFileSync(root_path, DEFAULT_CONFIG_TEMPLATE);
+  } catch {
+    p.log.error(
+      `${color.red("Could not determine git root folder. better-commits-init must be used in a git repository")}`,
+    );
+  }
   p.log.success(
     `${color.green(`Successfully created ${root_path.split("/").pop()}`)}`,
   );

--- a/src/init.ts
+++ b/src/init.ts
@@ -3,23 +3,44 @@
 import * as p from "@clack/prompts";
 import fs from "fs";
 import color from "picocolors";
-import { parse } from "valibot";
-import { CONFIG_FILE_NAME, get_git_root } from "./utils";
-import { Config } from "./valibot-state";
+import { DEFAULT_CONFIG_TEMPLATE } from "./default-config-template";
+import {
+  CONFIG_FILE_NAME,
+  get_git_root,
+  get_repository_config_path,
+} from "./utils";
 
 try {
+  await create_init_config();
+} catch {
+  p.log.error(
+    `${color.red("Could not determine git root folder. better-commits-init must be used in a git repository")}`,
+  );
+}
+
+export async function create_init_config() {
   console.clear();
   p.intro(`${color.bgCyan(color.black(" better-commits-init "))}`);
   const root = get_git_root();
-  const root_path = `${root}/${CONFIG_FILE_NAME}`;
-  const default_config = parse(Config, {});
-  fs.writeFileSync(root_path, JSON.stringify(default_config, null, 4));
-  p.log.success(`${color.green("Successfully created .better-commits.json")}`);
+  const existing_config_path = get_repository_config_path(root);
+  const root_path = existing_config_path ?? `${root}/${CONFIG_FILE_NAME}`;
+
+  if (existing_config_path) {
+    const should_overwrite = (await p.confirm({
+      message: `${root_path.split("/").pop()} already exists. Replace with default .better-commits.jsonc?`,
+    })) as boolean;
+
+    if (p.isCancel(should_overwrite) || !should_overwrite) {
+      p.outro("Cancelled");
+      return;
+    }
+  }
+
+  fs.writeFileSync(root_path, DEFAULT_CONFIG_TEMPLATE);
+  p.log.success(
+    `${color.green(`Successfully created ${root_path.split("/").pop()}`)}`,
+  );
   p.outro(
     `Run ${color.bgBlack(color.white("better-commits"))} to start the CLI`,
-  );
-} catch (err: any) {
-  p.log.error(
-    `${color.red("Could not determine git root folder. better-commits-init must be used in a git repository")}`,
   );
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,164 @@
+import fs from "fs";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({
+  existsSync: vi.fn<typeof fs.existsSync>(),
+  readFileSync: vi.fn<typeof fs.readFileSync>(),
+  writeFileSync: vi.fn<typeof fs.writeFileSync>(),
+  intro: vi.fn(),
+  step: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  default: {
+    existsSync: mocked.existsSync,
+    readFileSync: mocked.readFileSync,
+    writeFileSync: mocked.writeFileSync,
+  },
+}));
+
+vi.mock("@clack/prompts", () => ({
+  intro: mocked.intro,
+  log: {
+    step: mocked.step,
+    error: mocked.error,
+    warn: mocked.warn,
+  },
+}));
+
+vi.mock("./args", () => ({
+  flags: {
+    git_args: "",
+  },
+}));
+
+vi.mock("child_process", () => ({
+  execSync: vi.fn(() => Buffer.from("/repo")),
+}));
+
+describe("load_setup", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocked.existsSync.mockReset();
+    mocked.readFileSync.mockReset();
+    mocked.writeFileSync.mockReset();
+    mocked.intro.mockReset();
+    mocked.step.mockReset();
+    mocked.error.mockReset();
+    mocked.warn.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("loads a plain JSON repository config", async () => {
+    const home = "/home/test";
+    vi.stubEnv("HOME", home);
+    mocked.existsSync.mockImplementation((file_path) =>
+      [
+        `${home}/.better-commits.json`,
+        "/repo/.better-commits.json",
+      ].includes(String(file_path)),
+    );
+    mocked.readFileSync.mockImplementation((file_path) => {
+      if (String(file_path) === "/repo/.better-commits.json") {
+        return JSON.stringify({ confirm_commit: false });
+      }
+
+      return JSON.stringify({ cache_last_value: false, overrides: {} });
+    });
+
+    const { load_setup } = await import("./utils");
+    const result = load_setup();
+
+    expect(result.config_source).toBe("repository");
+    expect(result.config.confirm_commit).toBe(false);
+  });
+
+  it("loads a JSONC repository config with comments and trailing commas", async () => {
+    const home = "/home/test";
+    vi.stubEnv("HOME", home);
+    mocked.existsSync.mockImplementation((file_path) =>
+      [
+        `${home}/.better-commits.jsonc`,
+        "/repo/.better-commits.jsonc",
+      ].includes(String(file_path)),
+    );
+    mocked.readFileSync.mockImplementation((file_path) => {
+      if (String(file_path) === "/repo/.better-commits.jsonc") {
+        return `{
+          // repo config
+          "confirm_commit": false,
+          "commit_body": {
+            "required": true,
+          },
+        }`;
+      }
+
+      return `{
+        "cache_last_value": false,
+        "overrides": {},
+      }`;
+    });
+
+    const { load_setup } = await import("./utils");
+    const result = load_setup();
+
+    expect(result.config_source).toBe("repository");
+    expect(result.config.confirm_commit).toBe(false);
+    expect(result.config.commit_body.required).toBe(true);
+  });
+
+  it("prefers .jsonc over .json when both exist", async () => {
+    const home = "/home/test";
+    vi.stubEnv("HOME", home);
+    mocked.existsSync.mockImplementation((file_path) =>
+      [
+        `${home}/.better-commits.jsonc`,
+        "/repo/.better-commits.jsonc",
+        "/repo/.better-commits.json",
+      ].includes(String(file_path)),
+    );
+    mocked.readFileSync.mockImplementation((file_path) => {
+      if (String(file_path) === "/repo/.better-commits.jsonc") {
+        return `{
+          "confirm_commit": false,
+        }`;
+      }
+
+      if (String(file_path) === "/repo/.better-commits.json") {
+        return JSON.stringify({ confirm_commit: true });
+      }
+
+      return `{
+        "cache_last_value": false,
+        "overrides": {},
+      }`;
+    });
+
+    const { load_setup } = await import("./utils");
+    const result = load_setup();
+
+    expect(result.config.confirm_commit).toBe(false);
+  });
+
+  it("writes the JSONC template when no config exists", async () => {
+    const home = "/home/test";
+    vi.stubEnv("HOME", home);
+    mocked.existsSync.mockReturnValue(false);
+
+    const { load_setup, CONFIG_FILE_NAME } = await import("./utils");
+    const { DEFAULT_CONFIG_TEMPLATE } = await import("./default-config-template");
+    const result = load_setup();
+
+    expect(result.config_source).toBe("none");
+    expect(mocked.writeFileSync).toHaveBeenCalledWith(
+      path.join(home, CONFIG_FILE_NAME),
+      DEFAULT_CONFIG_TEMPLATE,
+    );
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,19 +2,20 @@ import * as p from "@clack/prompts";
 import { execSync } from "child_process";
 import fs from "fs";
 import { homedir } from "os";
+import { parse as parse_jsonc } from "jsonc-parser";
 import color from "picocolors";
 import { InferOutput, ValiError, parse } from "valibot";
 import { Config } from "./valibot-state";
 import { V_BRANCH_ACTIONS } from "./valibot-consts";
 import { flags } from "./args";
 import Configstore from "configstore";
+import { DEFAULT_CONFIG_TEMPLATE } from "./default-config-template";
 
-export const CONFIG_FILE_NAME = ".better-commits.json";
-export const SPACE_TO_SELECT = `${color.dim("(<space> to select)")}`;
-export const A_FOR_ALL = `${color.dim(
-  "(<space> to select, <a> to select all)",
-)}`;
-export const OPTIONAL_PROMPT = `${color.dim("(optional)")}`;
+export const CONFIG_FILE_NAMES = [
+  ".better-commits.jsonc",
+  ".better-commits.json",
+] as const;
+export const CONFIG_FILE_NAME = CONFIG_FILE_NAMES[0];
 export const COMMIT_FOOTER_OPTIONS = [
   {
     value: "closes",
@@ -71,8 +72,8 @@ export function load_setup(
   }
 
   const root = get_git_root(git_args);
-  const root_path = `${root}/${CONFIG_FILE_NAME}`;
-  if (fs.existsSync(root_path)) {
+  const root_path = get_repository_config_path(root);
+  if (root_path) {
     p.log.step("Reading from Repository Config");
     const repo_config = read_config_from_path(root_path);
     return {
@@ -100,9 +101,9 @@ export function load_setup(
 
   const default_config = parse(Config, {});
   p.log.step(
-    "Config not found. Generating default .better-commit.json at $HOME",
+    `Config not found. Generating default ${CONFIG_FILE_NAME} at $HOME`,
   );
-  fs.writeFileSync(home_path, JSON.stringify(default_config, null, 4));
+  fs.writeFileSync(home_path, DEFAULT_CONFIG_TEMPLATE);
   return {
     config: default_config,
     config_source: "none",
@@ -112,7 +113,7 @@ export function load_setup(
 function read_config_from_path(config_path: string) {
   let res = null;
   try {
-    res = JSON.parse(fs.readFileSync(config_path, "utf8"));
+    res = parse_jsonc(fs.readFileSync(config_path, "utf8"));
   } catch (err) {
     p.log.error("Invalid JSON file. Exiting.\n" + err);
     process.exit(0);
@@ -161,7 +162,20 @@ export function get_git_root(git_args = flags.git_args): string {
 }
 
 export function get_default_config_path(): string {
-  return homedir() + "/" + CONFIG_FILE_NAME;
+  return get_config_path(homedir()) ?? homedir() + "/" + CONFIG_FILE_NAME;
+}
+
+export function get_repository_config_path(root: string): string | null {
+  return get_config_path(root);
+}
+
+function get_config_path(base_path: string): string | null {
+  for (const file_name of CONFIG_FILE_NAMES) {
+    const config_path = `${base_path}/${file_name}`;
+    if (fs.existsSync(config_path)) return config_path;
+  }
+
+  return null;
 }
 
 export function get_package_version(): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,7 +115,9 @@ function read_config_from_path(config_path: string) {
   try {
     res = parse_jsonc(fs.readFileSync(config_path, "utf8"));
   } catch (err) {
-    p.log.error("Invalid JSON file. Exiting.\n" + err);
+    p.log.error(
+      `Invalid JSON/JSONC config file at ${config_path}. Exiting.\n` + err,
+    );
     process.exit(0);
   }
 


### PR DESCRIPTION
Condenses documentation via a jsonc example with comments.
The default config will be this same jsonc example.
Check for both a jsonc / json file, prefer the former.
better-commits-init will now ask for confirmation if you already have a config.

Potential breaking change for external scripts/tooling that are specifically looking for `.better-commits.json` in a new project that generates a `.better-commits.jsonc`. In existing projects, better-commits will still use the legacy `better-commits.json` and not overwrite unless explicitly told to via `better-commits-init`.