### PR TITLE
chore: remove unnecessary type check

### DIFF
--- a/src/utils/strip-json-comments.ts
+++ b/src/utils/strip-json-comments.ts
@@ -34,12 +34,6 @@ export function stripJsonComments(
   jsonString: string,
   { whitespace = true, trailingCommas = false }: StripJsonCommentsOptions = {},
 ): string {
-  if (typeof jsonString !== "string") {
-    throw new TypeError(
-      `Expected argument \`jsonString\` to be a \`string\`, got \`${typeof jsonString}\``,
-    );
-  }
-
   const strip = whitespace ? stripWithWhitespace : stripWithoutWhitespace;
 
   let isInsideString = false;


### PR DESCRIPTION
Removed unnecessary `typeof jsonString !== "string"` check since TypeScript guarantees the type will be `string`
